### PR TITLE
docs: update README login instructions and add Windows note

### DIFF
--- a/.changeset/readme-login-updates.md
+++ b/.changeset/readme-login-updates.md
@@ -1,0 +1,5 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Updated README login instructions: clarified provider dropdown selection, simplified install command, and added Windows note about console window during OAuth.

--- a/packages/pi-cursor/README.md
+++ b/packages/pi-cursor/README.md
@@ -18,29 +18,8 @@ A [Pi](https://github.com/badlogic/pi) extension that gives you access to all yo
 
 ## Installation
 
-From npm:
-
 ```bash
-pi install @schultzp2020/pi-cursor
-```
-
-Or from source:
-
-```bash
-git clone https://github.com/schultzp2020/pi-extensions.git
-cd pi-extensions
-npm install
-npm run build
-```
-
-Then load via symlink:
-
-```bash
-# Windows
-mklink /D "%USERPROFILE%\.pi\agent\extensions\pi-cursor" "C:\path\to\pi-cursor"
-
-# macOS / Linux
-ln -s /path/to/pi-cursor ~/.pi/agent/extensions/pi-cursor
+pi install npm:@schultzp2020/pi-cursor
 ```
 
 ## Usage
@@ -50,10 +29,12 @@ ln -s /path/to/pi-cursor ~/.pi/agent/extensions/pi-cursor
 Inside Pi, run:
 
 ```
-/login cursor
+/login
 ```
 
-Your browser opens to Cursor's OAuth page. After you log in, Pi polls until authentication completes. Tokens are stored and refreshed automatically.
+Select **Cursor** from the provider dropdown, then your browser opens to Cursor's OAuth page. After you log in, Pi polls until authentication completes. Tokens are stored and refreshed automatically.
+
+> **Windows note:** A console window may appear briefly when the browser opens. This is harmless — you can close it safely.
 
 ### 2. Select a model
 

--- a/packages/pi-cursor/package.json
+++ b/packages/pi-cursor/package.json
@@ -7,6 +7,7 @@
     "extension",
     "openai",
     "pi",
+    "pi-package",
     "proxy"
   ],
   "license": "MIT",


### PR DESCRIPTION
## Changes

- Simplified install command to `pi install npm:@schultzp2020/pi-cursor`
- Updated `/login` instructions to mention selecting **Cursor** from the provider dropdown
- Added Windows note about the harmless console window that appears during OAuth