### PR TITLE
fix: avoid redundant model discovery when connecting to existing proxy

### DIFF
--- a/.changeset/fix-duplicate-model-discovery.md
+++ b/.changeset/fix-duplicate-model-discovery.md
@@ -1,0 +1,9 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Fix duplicate model discovery on proxy startup
+
+When connecting to an existing proxy, `connectToProxy` called `/internal/refresh-models` which triggered a full `discoverCursorModels()` round-trip to Cursor's API — even though the proxy already had fresh models cached from startup. This caused the `Discovered N models via AvailableModels` log to appear twice.
+
+Added a `GET /internal/models` endpoint that returns cached models without re-discovering, and switched `connectToProxy` to use it. The `/internal/refresh-models` POST endpoint is preserved for explicit refresh scenarios.

--- a/packages/pi-cursor/src/proxy-lifecycle.ts
+++ b/packages/pi-cursor/src/proxy-lifecycle.ts
@@ -115,9 +115,8 @@ export async function pushToken(port: number, accessToken: string): Promise<void
   }
 }
 
-async function refreshModels(port: number): Promise<CursorModel[]> {
-  const res = await fetch(`http://localhost:${String(port)}/internal/refresh-models`, {
-    method: 'POST',
+async function getModels(port: number): Promise<CursorModel[]> {
+  const res = await fetch(`http://localhost:${String(port)}/internal/models`, {
     signal: AbortSignal.timeout(MODEL_REFRESH_TIMEOUT_MS),
   })
   const data = (await res.json()) as { models: CursorModel[] }
@@ -142,7 +141,7 @@ export async function connectToProxy(
       await pushToken(existing.port, accessToken)
     }
     startHeartbeat(existing.port, existing.pid, sessionId)
-    const models = await refreshModels(existing.port)
+    const models = await getModels(existing.port)
     return { port: existing.port, models }
   }
 

--- a/packages/pi-cursor/src/proxy/internal-api.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.ts
@@ -108,6 +108,11 @@ export async function handleInternalRequest(req: IncomingMessage, res: ServerRes
     return
   }
 
+  if (path === '/internal/models' && req.method === 'GET') {
+    jsonResponse(res, 200, { models: cachedModels })
+    return
+  }
+
   if (path === '/internal/refresh-models' && req.method === 'POST') {
     if (!currentAccessToken) {
       jsonResponse(res, 400, { error: 'no access token' })


### PR DESCRIPTION
## Problem

When connecting to an existing proxy, `connectToProxy` called `/internal/refresh-models` which triggered a full `discoverCursorModels()` round-trip to Cursor's API — even though the proxy already had fresh models cached from startup. This caused the `Discovered N models via AvailableModels` log to appear twice:

```
[cursor-proxy] [models] Discovered 169 models via AvailableModels
[cursor-proxy] [proxy] Discovered 169 models
[cursor-proxy] [proxy] Listening on port 57041
[cursor-proxy] [models] Discovered 169 models via AvailableModels   ← redundant
```

## Fix

- Add `GET /internal/models` endpoint that returns cached models without re-discovering
- Switch `connectToProxy` to use the cached endpoint instead of `/internal/refresh-models`
- Preserve `POST /internal/refresh-models` for explicit refresh scenarios