### PR TITLE
fix: correct native tool argument mapping for Pi MCP tools

### DIFF
--- a/.changeset/fix-native-tool-arg-mapping.md
+++ b/.changeset/fix-native-tool-arg-mapping.md
@@ -1,0 +1,12 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Fix native tool argument mapping for Pi MCP tools
+
+Several native Cursor tool redirects sent incorrect arguments to Pi's MCP tools, causing validation failures:
+
+- **`readArgs`/`writeArgs`**: Sent `filePath` instead of `path`, causing `Validation failed for tool "read": path: must have required properties path`
+- **`lsArgs`**: Redirected to nonexistent `glob` tool instead of Pi's `ls` tool
+- **`deleteArgs`/`fetchArgs`**: Sent extra `description` parameter not in `bash` tool schema
+- **`fixMcpArgNames`**: Converted `path` → `filePath` (backwards) — now correctly converts `filePath` → `path` and covers all Pi tools with a `path` parameter (`read`, `write`, `edit`, `grep`, `find`, `ls`)

--- a/packages/pi-cursor/src/proxy/cursor-messages.ts
+++ b/packages/pi-cursor/src/proxy/cursor-messages.ts
@@ -133,7 +133,7 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
   const toolCallId: string = (args?.toolCallId as string) || crypto.randomUUID()
 
   if (execCase === 'readArgs') {
-    const mcpArgs: Record<string, unknown> = { filePath: args.path }
+    const mcpArgs: Record<string, unknown> = { path: args.path }
     if (args.offset !== null && args.offset !== undefined && args.offset !== 0) {
       mcpArgs.offset = args.offset
     }
@@ -155,7 +155,7 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
     return {
       toolCallId,
       toolName: 'write',
-      decodedArgs: JSON.stringify({ filePath: args.path, content: fileContent }),
+      decodedArgs: JSON.stringify({ path: args.path, content: fileContent }),
       nativeResultType: 'writeResult',
       nativeArgs: { path: String(args.path ?? '') },
     }
@@ -167,7 +167,7 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
       return {
         toolCallId,
         toolName: 'bash',
-        decodedArgs: JSON.stringify({ command: 'true', description: 'No-op delete (empty path)' }),
+        decodedArgs: JSON.stringify({ command: 'true' }),
         nativeResultType: 'deleteResult',
         nativeArgs: { path: '' },
       }
@@ -176,7 +176,7 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
     return {
       toolCallId,
       toolName: 'bash',
-      decodedArgs: JSON.stringify({ command: `rm -f '${safePath}'`, description: `Delete ${rawPath}` }),
+      decodedArgs: JSON.stringify({ command: `rm -f '${safePath}'` }),
       nativeResultType: 'deleteResult',
       nativeArgs: { path: rawPath },
     }
@@ -210,8 +210,8 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
     const path = String(args.path ?? '.')
     return {
       toolCallId,
-      toolName: 'glob',
-      decodedArgs: JSON.stringify({ pattern: `${path}/**` }),
+      toolName: 'ls',
+      decodedArgs: JSON.stringify({ path }),
       nativeResultType: 'lsResult',
       nativeArgs: { path },
     }
@@ -223,7 +223,7 @@ function nativeToMcpRedirect(execCase: string, execMsg: ExecServerMessage): Nati
     return {
       toolCallId,
       toolName: 'bash',
-      decodedArgs: JSON.stringify({ command: `curl -sL '${safeUrl}'`, description: `Fetch ${rawUrl}` }),
+      decodedArgs: JSON.stringify({ command: `curl -sL '${safeUrl}'` }),
       nativeResultType: 'fetchResult',
       nativeArgs: { url: rawUrl },
     }

--- a/packages/pi-cursor/src/proxy/native-tools.test.ts
+++ b/packages/pi-cursor/src/proxy/native-tools.test.ts
@@ -13,23 +13,23 @@ describe('stripMcpToolPrefix', () => {
 })
 
 describe('fixMcpArgNames', () => {
-  it('renames path to filePath for read', () => {
-    const args: Record<string, unknown> = { path: 'foo.ts' }
+  it('renames filePath to path for read', () => {
+    const args: Record<string, unknown> = { filePath: 'foo.ts' }
     fixMcpArgNames('read', args)
-    expect(args.filePath).toBe('foo.ts')
-    expect(args.path).toBeUndefined()
+    expect(args.path).toBe('foo.ts')
+    expect(args.filePath).toBeUndefined()
   })
 
-  it('does not overwrite existing filePath', () => {
-    const args: Record<string, unknown> = { filePath: 'bar.ts', path: 'foo.ts' }
+  it('does not overwrite existing path', () => {
+    const args: Record<string, unknown> = { path: 'bar.ts', filePath: 'foo.ts' }
     fixMcpArgNames('read', args)
-    expect(args.filePath).toBe('bar.ts')
+    expect(args.path).toBe('bar.ts')
   })
 
-  it('renames path to filePath for write', () => {
-    const args: Record<string, unknown> = { path: 'out.ts', content: 'hello' }
+  it('renames filePath to path for write', () => {
+    const args: Record<string, unknown> = { filePath: 'out.ts', content: 'hello' }
     fixMcpArgNames('write', args)
-    expect(args.filePath).toBe('out.ts')
+    expect(args.path).toBe('out.ts')
   })
 })
 

--- a/packages/pi-cursor/src/proxy/native-tools.ts
+++ b/packages/pi-cursor/src/proxy/native-tools.ts
@@ -6,12 +6,12 @@ export function stripMcpToolPrefix(name: string): string {
   return name.startsWith(MCP_TOOL_PREFIX) ? name.slice(MCP_TOOL_PREFIX.length) : name
 }
 
-/** Fixes argument name mismatches — Cursor sometimes sends `path` instead of `filePath`. */
+/** Fixes argument name mismatches — Cursor sometimes sends `filePath` instead of `path`. */
 export function fixMcpArgNames(toolName: string, args: Record<string, unknown>): void {
-  // For read/write/edit tools, Cursor sometimes sends 'path' instead of 'filePath'
-  if (['read', 'write', 'edit'].includes(toolName) && args.path && !args.filePath) {
-    args.filePath = args.path
-    delete args.path
+  // Cursor sometimes sends 'filePath' instead of 'path' for tools that expect 'path'
+  if (['read', 'write', 'edit', 'grep', 'find', 'ls'].includes(toolName) && args.filePath && !args.path) {
+    args.path = args.filePath
+    delete args.filePath
   }
 }
 


### PR DESCRIPTION
## Problem

When Cursor models called Pi's MCP tools through the proxy, several native tool redirects sent incorrect arguments, causing validation failures like:

```
Validation failed for tool "read":
  - path: must have required properties path
Received: { "filePath": "src/proxy/cursor-messages.test.ts" }
```

## Root Cause

The argument mappings between Cursor's native tools and Pi's MCP tools were wrong in multiple places:

| Redirect | Bug | Fix |
|----------|-----|-----|
| `readArgs → read` | Sent `filePath` instead of `path` | Changed to `path` |
| `writeArgs → write` | Sent `filePath` instead of `path` | Changed to `path` |
| `deleteArgs → bash` | Sent extra `description` param (not in bash schema) | Removed `description` |
| `lsArgs → glob` | Tool `glob` doesn't exist in Pi — Pi has `ls` | Changed to `ls` with `{path}` |
| `fetchArgs → bash` | Sent extra `description` param (not in bash schema) | Removed `description` |
| `fixMcpArgNames` | Converted `path → filePath` (backwards!) | Reversed to `filePath → path`, extended to cover `grep`, `find`, `ls` |

## Changes

- **`src/proxy/native-tools.ts`**: Reversed `fixMcpArgNames` to convert `filePath → path` and extended to all Pi tools with a `path` param
- **`src/proxy/cursor-messages.ts`**: Fixed `nativeToMcpRedirect` for read, write, delete, ls, and fetch
- **`src/proxy/native-tools.test.ts`**: Updated tests to match corrected behavior

## Verified

- All 11 native-tools tests pass