### PR TITLE
docs: /cursor settings, model normalization, and session correctness

### DIFF
--- a/packages/pi-cursor/CONTEXT.md
+++ b/packages/pi-cursor/CONTEXT.md
@@ -25,54 +25,106 @@ A JSON file at `~/.pi/agent/cursor-proxy.json` containing the Proxy's port and P
 _Avoid_: lock file, discovery file
 
 **Session ID**:
-A unique identifier sent via `X-Session-Id` header with every request to the Proxy. Used to isolate Bridges, Checkpoints, and Blob Stores between different Pi sessions sharing the same Proxy.
-_Avoid_: session key, session token
+The real Pi session ID, injected into every request via the `pi_session_id` field in the request body using a `before_provider_request` hook. Used to isolate Bridges, Checkpoints, and Blob Stores between different Pi sessions sharing the same Proxy.
+_Avoid_: session key, session token, X-Session-Id header
 
 **Model Discovery**:
-A gRPC call to Cursor's `GetUsableModels` endpoint that returns all models the user's subscription can access. Performed once on Proxy startup, and again on demand via the Internal API.
+A gRPC call to Cursor's `AvailableModels` or `GetUsableModels` endpoint that returns all models the user's subscription can access. Performed once on Proxy startup, and again on demand via the Internal API or `/cursor` command.
 _Avoid_: model fetch, model sync
 
 **Model Cache**:
 A JSON file on disk containing the last successful Model Discovery result. Used on startup to register models immediately, then refreshed in the background.
 _Avoid_: model list, model registry
 
+**Fallback Models**:
+A static JSON file (`cursor-models-raw.json`) shipped with the extension containing a snapshot of known Cursor model IDs. Used to register models before login when no Model Cache exists.
+_Avoid_: default models, hardcoded models
+
+**Model Normalization**:
+The process of collapsing raw Cursor model variants into deduplicated Pi-visible models. Raw IDs encode up to four dimensions: effort level, speed (`-fast`), thinking (`-thinking`), and maxMode (trailing `-max`). Parsing strips suffixes in order: trailing `-max` first, then `-fast`, then `-thinking`, then effort from the last remaining segment. Controlled by the `modelMappings` setting.
+_Avoid_: model dedup, model collapse
+
+**Effort Map**:
+A per-model mapping from Pi's reasoning-effort levels (`minimal`, `low`, `medium`, `high`, `xhigh`) to the best available Cursor effort suffix for that family. Built dynamically from the family's actual effort set using `buildEffortMap`. In current Cursor data, `xhigh` and `max` are mutually exclusive per family — GPT-style models use `xhigh`, Claude-style models use `max`. Registered via the provider's `reasoningEffortMap` compat field when a model `supportsReasoningEffort`.
+_Avoid_: effort table, reasoning map
+
+**Effort Resolution**:
+The process of reconstructing the final Cursor model ID at request time by inserting the mapped effort suffix before any `-fast` or `-thinking` variant suffix. Performed by the Proxy using the Effort Map and global settings.
+_Avoid_: model resolution, effort insertion
+
+**Max Mode**:
+A global setting (`maxMode`) that appends a trailing `-max` suffix to the final Cursor model ID, activating Cursor's max capability mode. Best-effort — silently ignored if the model family has no max variant. Separate from the `max` effort suffix, which is one of Cursor's effort levels that can appear in both Claude-style and GPT-style families and maps to Pi's `xhigh` reasoning level. Also distinct from `max` appearing in a base model name (e.g. `gpt-5.1-codex-max`), which is part of the model identity. All three meanings of `max` are independent and can compose: `claude-4.6-opus-max-thinking-fast-max` has effort `max`, thinking variant, fast variant, and maxMode flag.
+_Avoid_: max effort, max variant (when referring to the global toggle)
+
 **Proxy Reconnect**:
 The process of a newly loaded extension instance reconnecting to an existing Proxy that survived a reload or session switch. Uses the Port File for discovery across sessions, and `pi.appendEntry()` for fast reconnect within the same session during `/reload`.
 _Avoid_: rediscovery, reattach
 
 **Checkpoint**:
-A protobuf snapshot of conversation state that Cursor's server sends after significant state changes. Persisted to disk so sessions survive Proxy restarts.
+A protobuf snapshot of conversation state that Cursor's server sends after significant state changes. Persisted to disk so sessions survive Proxy restarts. Committed only after a turn completes successfully — never on interruption or client disconnect.
 _Avoid_: state, snapshot, save
 
+**Checkpoint Lineage**:
+Metadata stored alongside the latest committed Checkpoint: completed turn count and a fingerprint of the completed structured history. Used to detect stale Checkpoints after forks, compaction, or branch navigation.
+_Avoid_: checkpoint history, checkpoint version
+
 **Blob Store**:
-A key-value store of binary data (system prompts, conversation chunks) that Cursor's server requests back via KV handshake messages. Persisted to disk alongside Checkpoints.
+A content-addressed key-value store of binary data (system prompts, user messages, conversation turns) using SHA256-based IDs. Cursor's server requests blobs back via KV handshake messages. Persisted to disk alongside Checkpoints.
 _Avoid_: cache, KV store
 
-**Native Tool Redirection**:
-Intercepting Cursor's built-in tool calls and translating them to Pi's equivalent tools where a clean mapping exists (readArgs→read, shellArgs→bash, grepArgs→grep, writeArgs→write, lsArgs→ls, deleteArgs→bash rm, fetchArgs→bash curl). Redirects are gated against the session's enabled tool set before execution, so disabled tools are rejected instead of bypassing Pi's requested `tools` array. The result flows back as native protobuf so the model never retries. Obscure tools with no Pi equivalent (diagnostics, computerUse, recordScreen, backgroundShellSpawn) are rejected with an explanatory error.
-_Avoid_: tool mapping, tool proxy, native tool rejection
+**Native Tools Mode**:
+A global setting (`nativeToolsMode`) controlling how Cursor's built-in tool calls are handled. Three modes:
+
+- **`reject`** (default): All native Cursor tool calls are rejected. Only explicit MCP/Pi tools succeed.
+- **`redirect`**: Overlapping native tools are transparently executed through Pi equivalents. Remaining Cursor tools stay available.
+- **`native`**: Overlapping tools are executed as true proxy-local operations (sandboxed to the nearest git root of `ctx.cwd`). Non-overlapping Pi MCP tools remain available but the "prefer mcp*pi*\*" prompt guidance is removed.
+  _Avoid_: tool policy, tool mode
+
+**Overlapping Tools**:
+The set of Cursor native tools that have direct Pi equivalents: `readArgs`, `writeArgs`, `deleteArgs`, `shellArgs`, `shellStreamArgs`, `lsArgs`, `grepArgs`, `fetchArgs`. These are the tools affected by the `redirect` and `native` modes.
+_Avoid_: mapped tools, redirectable tools
+
+**Remaining Tools**:
+Cursor native tools with no Pi equivalent: `backgroundShellSpawnArgs`, `writeShellStdinArgs`, `diagnosticsArgs`, `webSearchRequestQuery`, `exaSearchRequestQuery`, `exaFetchRequestQuery`, `askQuestionInteractionQuery`, `switchModeRequestQuery`, `createPlanRequestQuery`. These are rejected in `reject` mode and passthrough/rejected in `native`/`redirect` modes depending on implementation status.
+_Avoid_: unmapped tools, unsupported tools
 
 **Tool Gating**:
 Filtering every MCP passthrough, native redirect, and implicit Cursor interaction feature against the tool set Pi explicitly registered for the session. Unenabled tools return explicit rejection or `isError: true` responses so the model falls back to the tools Pi actually allowed.
 _Avoid_: tool allowlist, permission layer, tool ACL
+
+**Allowed Root**:
+The filesystem boundary for proxy-local native tool execution in `native` mode. Captured once per session from the nearest git root containing `ctx.cwd`, falling back to `ctx.cwd` if no git repo is found. Paths outside this root are rejected.
+_Avoid_: workspace root, sandbox root
 
 **MCP Tool**:
 A tool definition registered via Cursor's `RequestContext` that the model uses as a fallback when no native tool redirection applies. These map 1:1 to Pi's tool definitions.
 _Avoid_: external tool, custom tool
 
 **Cloud Rule**:
-A text field in Cursor's `RequestContext` protobuf message used to deliver system-level instructions that the model respects. Used instead of the `system` role, which Cursor ignores.
+A text field in Cursor's `RequestContext` protobuf message used to deliver system-level instructions that the model respects. Used instead of the `system` role, which Cursor ignores. Prompt guidance varies by Native Tools Mode.
 _Avoid_: system prompt, system message, rules
+
+**Cursor Config**:
+A global JSON file at `~/.pi/agent/cursor-config.json` containing explicit user settings: `nativeToolsMode`, `maxMode`, `modelMappings`, `maxRetries`. Versioned with a `version` field. Environment variables override config file values, which override built-in defaults.
+_Avoid_: settings file, preferences
+
+**`/cursor` Command**:
+A Pi command that opens a single-level settings menu. Each row opens a second selector of valid values. Settings persist to the Cursor Config file and take effect on new requests.
+_Avoid_: cursor settings, config command
 
 ## Relationships
 
 - The **Proxy** spawns one or more **Bridges** to handle concurrent requests, isolated by **Session ID**
-- A **Bridge** translates **Native Tool Redirection** calls into OpenAI `tool_calls` for Pi, with results sent back as native protobuf
+- A **Bridge** translates tool calls according to the current **Native Tools Mode**: reject, redirect through Pi, or execute locally within the **Allowed Root**
 - A **Bridge** translates **MCP Tool** calls into OpenAI `tool_calls` for Pi, with results sent back as MCP protobuf
-- The **Proxy** persists **Checkpoints** and **Blob Store** data to disk, keyed by **Session ID** + conversation
+- The **Proxy** persists **Checkpoints**, **Checkpoint Lineage**, and **Blob Store** data to disk, keyed by **Session ID** + conversation
+- The **Proxy** validates **Checkpoint Lineage** on every request — discards stale Checkpoints on fork, compaction, or branch navigation
 - The **Proxy** exposes the **Internal API** for heartbeats, token delivery, and model refresh
 - Extension instances discover the **Proxy** via the **Port File**, or spawn a new one if none exists
 - **Model Discovery** results are cached to disk as the **Model Cache** for fast subsequent startups
+- **Model Normalization** collapses raw Cursor variants into deduplicated models with **Effort Maps**
+- **Effort Resolution** combines the normalized model, **Max Mode**, and Pi's reasoning-effort setting to reconstruct the final Cursor model ID
+- The **`/cursor` Command** edits the **Cursor Config** and triggers provider re-registration when **Model Normalization** mode changes
 
 ## Example dialogue
 
@@ -80,10 +132,18 @@ _Avoid_: system prompt, system message, rules
 > **Domain expert:** "No — it reads the Port File, finds the existing Proxy, verifies the PID, and starts heartbeating via the Internal API. Each session's requests are isolated by Session ID."
 
 > **Dev:** "What happens when Cursor's model tries to use its native `read` tool?"
-> **Domain expert:** "The Proxy intercepts it via Native Tool Redirection — translates `readArgs` to Pi's `read` tool, executes it, and sends the result back as a native `ReadResult` protobuf. The model never knows it was redirected."
+> **Domain expert:** "That depends on the Native Tools Mode. In `reject` mode (the default), it's rejected with an error message. In `redirect` mode, it's translated to Pi's `read` tool. In `native` mode, the Proxy reads the file directly within the Allowed Root."
+
+> **Dev:** "How does the model list differ from what Cursor shows?"
+> **Domain expert:** "When `modelMappings` is `normalized` (the default), effort-level variants are collapsed. So `gpt-5.4-low`, `gpt-5.4-medium`, `gpt-5.4-high` become a single `gpt-5.4` entry with Pi's reasoning-effort setting controlling the actual variant. Set `modelMappings` to `raw` or `PI_CURSOR_RAW_MODELS=1` to see all raw variants."
+
+> **Dev:** "What happens after session compaction?"
+> **Domain expert:** "The Proxy derives conversation keys from the stable Pi Session ID, not from message content. After compaction the history changes but the session ID stays the same, so the Proxy finds the right conversation state. The Checkpoint Lineage detects that the history fingerprint no longer matches and discards the stale checkpoint, then reconstructs turns from the compacted history."
 
 ## Flagged ambiguities
 
 - "bridge" in the opencode-cursor reference means both "the H2 connection" and "the Node child process that wraps it." Here, **Bridge** means the H2 connection only — the child process wrapper is eliminated because Pi runs on Node.js natively.
 - "cost" — Pi tracks per-model costs in $/million tokens. Cursor models report **zero cost** because the user pays via their Cursor subscription, not per-token through this extension. Token counts (input/output/cache) are still tracked.
 - "heartbeat" — Two different heartbeats exist: the extension→Proxy heartbeat via Internal API (proves sessions are alive), and the Proxy→Cursor heartbeat on the H2 stream (keeps the Bridge alive). Context makes the distinction clear.
+- "max" — Overloaded three ways. **Trailing `-max` suffix** is the maxMode flag (stripped first during parsing, controlled by global Max Mode setting). **Effort suffix `max`** is one of Cursor's effort levels that can coexist with `xhigh` in the same family, mapped to Pi's `xhigh` reasoning level. **Base name `max`** (e.g. `gpt-5.1-codex-max`) is part of the model identity. All three are independent and can compose in a single model ID (e.g. `claude-4.6-opus-max-thinking-fast-max` = base `claude-4.6-opus`, effort `max`, thinking, fast, maxMode on).
+- "native" — In the Native Tools Mode context, "native" means Cursor's built-in tools executed as true proxy-local operations. Not to be confused with Pi's native tools.

--- a/packages/pi-cursor/docs/adr/0004-session-identity-from-pi-session-id.md
+++ b/packages/pi-cursor/docs/adr/0004-session-identity-from-pi-session-id.md
@@ -1,0 +1,22 @@
+# Session identity derived from Pi session ID, not message content
+
+Session keys, conversation keys, and bridge keys are derived from Pi's stable session ID (`pi_session_id` injected via `before_provider_request`), not from hashing the first user message content.
+
+The previous approach (`X-Session-Id` header with a random per-extension UUID + first user message hash) broke after session compaction: Pi replaces conversation history with a summary, changing the first user message, which produced different keys and orphaned all stored state (checkpoints, blob stores, active bridges).
+
+## Considered Options
+
+- **A: Content-based key derivation** (current) — Hash first user message for keys. Breaks on compaction, branch rewind, or any history rewrite. No code change needed.
+- **B: Pi session ID via header** — Stable across compaction, but headers are out-of-band and harder to log/replay.
+- **C: Pi session ID in request body** — Stable across compaction, travels with the payload, easy to log. Matches upstream approach. Requires `before_provider_request` hook.
+
+## Decision
+
+Option C. The extension injects `pi_session_id` into the request body via `before_provider_request`. The proxy extracts it and derives all session/conversation/bridge keys from it. Anonymous fallback (no session ID) degrades to content-based derivation for backward compatibility.
+
+## Consequences
+
+- Session compaction no longer breaks Cursor conversations.
+- Fork, branch navigation, and `/tree` produce correct checkpoint invalidation via lineage fingerprint rather than key miss.
+- The extension must register a `before_provider_request` hook.
+- Lifecycle cleanup hooks (`session_before_switch`, `session_before_fork`, `session_before_tree`, `session_shutdown`) can now clean up by real session ID.

--- a/packages/pi-cursor/docs/adr/0005-native-tools-mode-policy.md
+++ b/packages/pi-cursor/docs/adr/0005-native-tools-mode-policy.md
@@ -1,0 +1,29 @@
+# Three-mode native tools policy: reject, redirect, native
+
+Cursor's built-in tool calls are handled according to a configurable policy with three modes, defaulting to `reject`.
+
+The previous behavior was a hardcoded hybrid: overlapping tools were always redirected through Pi equivalents, and remaining tools were always rejected. This made the behavior implicit, untestable, and impossible to change without code edits.
+
+## Modes
+
+- **`reject`** (default) — All native Cursor tool calls are rejected. Only explicit MCP/Pi tools succeed. Strictest mode, matches Pi's simple-by-default philosophy.
+- **`redirect`** — Overlapping native tools (read, write, delete, shell, shellStream, ls, grep, fetch) are transparently executed through Pi's equivalent tools. Remaining Cursor tools are rejected unless explicitly supported.
+- **`native`** — Overlapping tools are executed as true proxy-local operations within the session's Allowed Root (nearest git root of `ctx.cwd`). The "prefer mcp*pi*\* tools" prompt guidance is removed. Remaining Cursor tools are rejected until explicitly implemented.
+
+## Considered Options
+
+- **A: Keep hardcoded redirect** — No user control, no clear contract, overlapping tools always go through Pi regardless of intent.
+- **B: Two modes (redirect/reject)** — Simpler, but no path to true native execution for users who want Cursor's original tool behavior.
+- **C: Three modes** — Full spectrum from strictest (reject) to most permissive (native). Each mode has clear, distinct semantics.
+
+## Decision
+
+Option C. Breaking change: default shifts from implicit redirect to explicit `reject`. Acceptable pre-1.0.
+
+## Consequences
+
+- `request-context.ts` must emit mode-dependent prompt guidance instead of always preferring `mcp_pi_*`.
+- `native` mode requires proxy-local tool implementations with filesystem sandboxing.
+- The Allowed Root is captured per session from the nearest git root containing `ctx.cwd`.
+- Unsupported remaining tools clearly reject in all modes for now, with room to implement them incrementally.
+- Setting is persisted in `cursor-config.json` and overridable via environment variable.

--- a/packages/pi-cursor/docs/adr/0006-model-normalization-and-effort-mapping.md
+++ b/packages/pi-cursor/docs/adr/0006-model-normalization-and-effort-mapping.md
@@ -1,0 +1,64 @@
+# Model normalization with effort mapping controlled by modelMappings setting
+
+Raw Cursor model IDs encode effort level, speed variant, and thinking mode as suffixes (e.g. `gpt-5.4-high-fast`, `claude-4.6-opus-max-thinking`). These are collapsed into deduplicated Pi-visible models with Pi's reasoning-effort setting controlling the actual variant sent to Cursor.
+
+## How it works
+
+Each raw Cursor model ID is parsed in order:
+
+1. Strip trailing `-max` → this is the **maxMode flag** (Cursor's max capability toggle), not an effort level
+2. Strip `-fast` → speed variant
+3. Strip `-thinking` → thinking variant
+4. Parse the last remaining segment for effort (`none`, `low`, `medium`, `high`, `xhigh`, `max`)
+
+This produces: `{base}[-{effort}][-thinking][-fast][-max(mode)]`
+
+Critical: `-max` has **three** meanings in Cursor model IDs:
+
+- **Trailing `-max`** → maxMode flag (stripped first, controlled by global Max Mode setting)
+- **Effort suffix `max`** → an effort level (e.g. `claude-4.6-opus-max` = effort `max` on base `claude-4.6-opus`)
+- **Base name component** → part of model identity (e.g. `gpt-5.1-codex-max` = a distinct model family)
+
+Models like `claude-4.6-opus-max-thinking-fast-max` have both effort `max` AND maxMode flag.
+
+Models sharing the same `(base, variant)` with multiple effort levels or a single non-empty effort suffix are collapsed into one entry with `supportsReasoningEffort: true` and a `reasoningEffortMap`.
+
+Pi's effort levels map to Cursor suffixes via `buildEffortMap`, which picks the best available match from the family's actual effort set:
+
+- `minimal` → `none` if available, else `low`, else lowest available
+- `low` → `low`
+- `medium` → `medium` or no suffix (default)
+- `high` → `high`
+- `xhigh` → `max` if available, else `xhigh`, else `high`
+
+`xhigh` and `max` effort suffixes **can coexist** in the same family (e.g. `gpt-5.2` has `{low, high, xhigh, max}`). When both exist, `max` is the higher effort and maps to Pi's `xhigh`.
+
+At request time the proxy reconstructs the full Cursor model ID: `base` + effort suffix + variant suffixes (`-thinking`/`-fast`) + maxMode suffix (`-max` if global Max Mode is on and the family supports it).
+
+## `modelMappings` setting
+
+- **`normalized`** (default) — Deduplicated model list, effort controlled by Pi.
+- **`raw`** — All raw Cursor variants exposed directly. Max Mode setting is hidden/disabled.
+
+Overridable via `PI_CURSOR_RAW_MODELS=1` environment variable.
+
+## Max Mode interaction
+
+Max Mode is a separate global toggle. When enabled, the proxy requests the max-capability variant if one exists in the family. When `modelMappings=raw`, Max Mode is hidden because users can select raw `*-max` variants directly.
+
+## Considered Options
+
+- **A: Expose all raw variants** — Simple, but 83+ models overwhelm the picker and duplicate the same model 4-6x.
+- **B: Always deduplicate** — Clean picker, but no escape hatch for debugging or edge cases.
+- **C: Configurable via `modelMappings`** — Clean default with a debug/power-user escape hatch.
+
+## Decision
+
+Option C. Normalization data is derived at runtime from model discovery, never persisted as config.
+
+## Consequences
+
+- Switching `modelMappings` triggers immediate provider re-registration.
+- Current model is preserved via best-match reconstruction from effective settings.
+- Cost metadata stays at zero (subscription model, no per-token costs).
+- Fallback models JSON provides a pre-login model list.

--- a/packages/pi-cursor/docs/adr/0007-global-cursor-config-with-env-override.md
+++ b/packages/pi-cursor/docs/adr/0007-global-cursor-config-with-env-override.md
@@ -1,0 +1,45 @@
+# Global cursor config file with environment variable override
+
+User settings for the Cursor provider are stored in `~/.pi/agent/cursor-config.json`, a versioned JSON file owned by the extension. Environment variables override file values, which override built-in defaults.
+
+## Schema (v1)
+
+```json
+{
+  "version": 1,
+  "nativeToolsMode": "reject",
+  "maxMode": false,
+  "modelMappings": "normalized",
+  "maxRetries": 2
+}
+```
+
+Only explicit user settings are stored. Model normalization data, cached models, and derived state are never persisted as config.
+
+## Precedence
+
+1. Environment variables (`PI_CURSOR_NATIVE_TOOLS_MODE`, `PI_CURSOR_MAX_MODE`, `PI_CURSOR_RAW_MODELS`, `PI_CURSOR_MAX_RETRIES`)
+2. `cursor-config.json`
+3. Built-in defaults
+
+## Resilience
+
+- Invalid JSON or malformed values → fall back to defaults, ignore bad fields
+- Unknown fields → ignored (forward compatibility)
+- Missing file → use defaults, create on first `/cursor` save
+
+## Considered Options
+
+- **A: Pi's built-in settings** — Pi has no global settings store for extensions. `pi.appendEntry()` is session-scoped.
+- **B: Environment variables only** — No persistence across sessions without shell profile editing.
+- **C: Config file + env override** — Persistent defaults with temporary override capability.
+
+## Decision
+
+Option C. The `/cursor` command edits the config file. Environment overrides are shown in the menu when active but cannot be changed via the UI (they override the persisted value for the current process).
+
+## Consequences
+
+- Settings are global across all Pi sessions sharing the same `~/.pi/agent/` directory.
+- Changes affect only new requests, not in-flight sessions.
+- Version field enables safe schema migration in future releases.

--- a/packages/pi-cursor/docs/adr/0008-checkpoint-lineage-for-fork-and-compaction-safety.md
+++ b/packages/pi-cursor/docs/adr/0008-checkpoint-lineage-for-fork-and-compaction-safety.md
@@ -1,0 +1,37 @@
+# Checkpoint lineage metadata for fork and compaction safety
+
+The proxy stores lightweight lineage metadata alongside the latest committed checkpoint: completed turn count and a SHA256 fingerprint of the completed structured history. On every request, the proxy validates this lineage against the incoming message history and discards the checkpoint on mismatch.
+
+## Problem
+
+Checkpoints become stale when:
+
+- The user navigates back in Pi's session tree and forks from an earlier point
+- Pi compacts the conversation (replaces history with a summary)
+- The user uses `/tree` to switch branches
+- The proxy restarts and receives history that has diverged from the stored checkpoint
+
+Without lineage validation, the proxy reuses a stale checkpoint, causing Cursor to see inconsistent conversation state — producing garbled responses or errors.
+
+## Design
+
+- **Completed turn count** — number of fully completed conversation turns at checkpoint commit time.
+- **Completed history fingerprint** — SHA256 of the serialized completed turns at checkpoint commit time.
+
+Mismatch detection:
+
+1. If incoming turn count ≠ stored turn count → discard checkpoint
+2. If incoming turn count matches but fingerprint differs (same-depth fork) → discard checkpoint
+3. On discard → reconstruct structured protobuf turns from the message history Pi sends
+
+## Checkpoint commit rules
+
+- Checkpoints are only committed after a turn completes successfully.
+- On client disconnect or interruption, the pending checkpoint is discarded and the previous committed checkpoint is preserved.
+- An explicit `CancelAction` protobuf is sent to Cursor on disconnect.
+
+## Consequences
+
+- Session compaction works correctly: stable session ID finds the state, lineage detects the history change, checkpoint is discarded, turns are reconstructed from compacted history.
+- Fork navigation works correctly: same mechanism detects branch divergence.
+- Slight overhead for fingerprint computation per request — negligible vs. network latency.

--- a/packages/pi-cursor/docs/prd-cursor-settings-and-model-normalization.md
+++ b/packages/pi-cursor/docs/prd-cursor-settings-and-model-normalization.md
@@ -1,0 +1,183 @@
+# PRD: `/cursor` Settings, Model Normalization, and Session Correctness
+
+## Problem Statement
+
+The pi-cursor extension exposes Cursor subscription models to Pi but has several gaps that hurt usability, correctness, and debuggability:
+
+1. **No user-facing settings.** Native tool behavior, max mode, and model mapping are hardcoded. Users cannot configure the extension without editing source code.
+
+2. **Model list is overwhelming.** Cursor exposes 169+ raw model variants encoding effort level, speed, thinking mode, and max capability in the model ID. Pi's `/model` picker shows all of them, making model selection tedious and confusing.
+
+3. **Sessions break after compaction.** Conversation keys are derived from message content. When Pi compacts the session (replacing history with a summary), the keys change, orphaning all stored state — checkpoints, blob stores, active bridges. The conversation dies.
+
+4. **Fork/branch navigation silently corrupts state.** There is no checkpoint lineage validation. Stale checkpoints are reused after forks, producing garbled Cursor responses.
+
+5. **Retry is unwired.** The proxy can detect retryable failures and signals `outcome: 'retry'`, but never actually retries. Transient Cursor errors kill the conversation.
+
+6. **Image-capable models don't work with images.** Models advertise image input support, but `openai-messages.ts` drops image content parts.
+
+7. **No debug tooling.** When things go wrong, there is no structured logging or timeline tool to diagnose what happened.
+
+8. **Native tool policy is implicit.** The extension always redirects overlapping native tools through Pi equivalents with no way to use Cursor's tools directly or reject them entirely.
+
+## Solution
+
+Ship a cohesive feature set that adds a `/cursor` settings command, persistent global config, model normalization with reasoning-effort mapping, correct session identity, checkpoint safety, retry execution, image bridging, configurable native-tool modes, and structured debug logging.
+
+After this change:
+
+- Users run `/cursor` to configure the extension (native tools mode, max mode, model mappings, retry count)
+- The model picker shows deduplicated models; Pi's reasoning-effort setting controls the underlying Cursor variant
+- Sessions survive compaction, forks, and branch navigation
+- Transient Cursor errors are retried automatically
+- Images work with image-capable models
+- Debug logging can be enabled with an environment variable
+
+## User Stories
+
+1. As a Pi user, I want to run `/cursor` and see a settings menu, so that I can configure the extension without editing code.
+2. As a Pi user, I want to change `nativeToolsMode` to `reject` so that only Pi's explicit tools are available and Cursor's native tools don't interfere.
+3. As a Pi user, I want to change `nativeToolsMode` to `native` so that Cursor's built-in tools execute locally for lower latency.
+4. As a Pi user, I want to change `nativeToolsMode` to `redirect` so that Cursor's overlapping tools transparently use Pi's implementations.
+5. As a Pi user, I want to toggle `maxMode` on so that my selected model uses Cursor's highest-capability variant when available.
+6. As a Pi user, I want `maxMode` to be silently ignored when my selected model has no max variant, so I don't have to think about per-model compatibility.
+7. As a Pi user, I want the model picker to show deduplicated models (e.g. one `gpt-5.4` instead of six effort variants), so model selection is not overwhelming.
+8. As a Pi user, I want Pi's reasoning-effort setting (minimal/low/medium/high/xhigh) to automatically select the right Cursor effort variant, so I don't have to manually pick effort-suffixed model IDs.
+9. As a Pi user, I want to set `modelMappings` to `raw` to see all original Cursor model variants when I need to debug or pick a specific variant.
+10. As a Pi user, I want switching `modelMappings` to immediately update the model picker without restarting Pi.
+11. As a Pi user, I want my `/cursor` settings to persist across Pi sessions, so I don't have to reconfigure every time.
+12. As a Pi user, I want to override settings temporarily via environment variables (e.g. `PI_CURSOR_RAW_MODELS=1`) without changing my persisted config.
+13. As a Pi user, I want conversations to survive session compaction, so I can use long sessions without Cursor losing context.
+14. As a Pi user, I want fork/branch navigation to correctly invalidate stale state, so I don't get garbled responses after navigating the session tree.
+15. As a Pi user, I want transient Cursor errors to be retried automatically, so temporary failures don't kill my conversation.
+16. As a Pi user, I want to configure the maximum number of retries via `/cursor`.
+17. As a Pi user, I want image content to work with image-capable Cursor models, so I can send screenshots and diagrams.
+18. As a Pi user, I want to enable debug logging with `PI_CURSOR_PROVIDER_DEBUG=1` to diagnose issues.
+19. As a Pi user, I want a timeline script that summarizes debug logs into a human-readable format.
+20. As a developer, I want the proxy to send an explicit cancel action to Cursor on client disconnect, so Cursor doesn't waste resources on abandoned turns.
+21. As a developer, I want checkpoints to only be committed after successful turn completion, so interrupted turns don't corrupt state.
+22. As a developer, I want session cleanup to happen on Pi lifecycle events (switch, fork, tree, shutdown), so proxy state doesn't leak across sessions.
+23. As a Pi user, I want native tools in `native` mode to be sandboxed to my project's git root, so the proxy can't accidentally access files outside my workspace.
+24. As a Pi user, I want settings changes to take effect on new requests without affecting in-flight conversations.
+25. As a Pi user, I want the `/cursor` menu to show when a setting is overridden by an environment variable.
+
+## Implementation Decisions
+
+### Config system
+
+- Global config file at `~/.pi/agent/cursor-config.json` with `version` field (starting at 1)
+- Stores only explicit user settings: `nativeToolsMode`, `maxMode`, `modelMappings`, `maxRetries`
+- Precedence: environment variables > config file > built-in defaults
+- Defaults: `nativeToolsMode=reject`, `maxMode=false`, `modelMappings=normalized`, `maxRetries=2`
+- Invalid/malformed files fall back to defaults; unknown fields are ignored
+
+### `/cursor` command
+
+- Single-level settings menu via `pi.registerCommand()` and `ctx.ui.select()`
+- Each row opens a second selector of valid values
+- Settings persist immediately on change
+- `maxMode` row is hidden/disabled when `modelMappings=raw`
+- Shows environment override indicators when applicable
+
+### Model normalization
+
+- Parser strips suffixes in order: trailing `-max` (maxMode flag), `-fast`, `-thinking`, then effort from last segment
+- Three meanings of `max`: trailing maxMode flag, effort level, base name component — all independent and composable
+- `xhigh` and `max` effort suffixes can coexist in the same family; when both exist, `max` is higher and maps to Pi's `xhigh`
+- Extension owns the visible model list and provider compat metadata
+- Proxy owns final raw Cursor model resolution at request time
+- Switching `modelMappings` triggers immediate provider re-registration with best-match model preservation
+- Normalization data is derived at runtime from model discovery, never persisted as config
+- Cost metadata stays at zero (subscription model)
+
+### Effort mapping
+
+- Pi levels map to Cursor suffixes via `buildEffortMap` using the family's available effort set
+- `minimal` → `none` or `low`; `low` → `low`; `medium` → `medium` or no suffix; `high` → `high`; `xhigh` → `max` or `xhigh` or `high`
+- Registered via provider `compat.supportsReasoningEffort` and `compat.reasoningEffortMap`
+
+### Native tools modes
+
+- `reject` (default, breaking change from previous implicit redirect): all native Cursor tools rejected
+- `redirect`: overlapping tools (read, write, delete, shell, shellStream, ls, grep, fetch) executed through Pi equivalents; remaining Cursor tools rejected
+- `native`: overlapping tools executed as true proxy-local operations sandboxed to nearest git root of `ctx.cwd`; Allowed Root captured per session; shell inherits normal process environment; `mcp_pi_*` preference guidance removed from prompt
+- Mode-dependent prompt guidance in `request-context.ts`
+- Unsupported remaining tools reject clearly in all modes
+
+### Session identity
+
+- Real Pi session ID injected via `before_provider_request` hook as `pi_session_id` in request body
+- All session/conversation/bridge keys derived from stable session ID
+- Lifecycle cleanup on `session_before_switch`, `session_before_fork`, `session_before_tree`, `session_shutdown`
+
+### Checkpoint safety
+
+- Lineage metadata: completed turn count + SHA256 fingerprint of completed structured history
+- Validate on every request; discard checkpoint on mismatch (fork, compaction, branch navigation)
+- Checkpoints committed only after successful turn completion
+- Explicit `CancelAction` protobuf sent to Cursor on client disconnect
+- Previous committed checkpoint preserved on interruption
+
+### Protobuf improvements
+
+- Content-addressed blob store with SHA256 IDs
+- Richer `ConversationStateStructure` fields: `rootPromptMessagesJson`, `previousWorkspaceUris`, `mode`, `clientName`
+- Full structured turn reconstruction: tool calls, tool results, post-tool assistant text
+- Deterministic conversation IDs derived from conversation key
+- Partial tool result resume (re-emit pending tool calls when not all results are back)
+
+### Retry
+
+- Proxy executes retries up to `maxRetries` (default 2) on retryable Cursor failures
+- Configurable via `/cursor` and `PI_CURSOR_MAX_RETRIES` env var
+
+### Image bridging
+
+- `openai-messages.ts` preserves and bridges image content parts to Cursor's protobuf format
+
+### Debug tooling
+
+- `PI_CURSOR_PROVIDER_DEBUG=1` enables structured JSONL logging
+- Extension-level hooks on `message_start`, `message_update`, `message_end`, `context`, `turn_end`
+- Proxy-level event logging with request/session IDs
+- `scripts/debug-log-timeline.mjs` for human-readable log summaries
+- Log file path configurable via `PI_CURSOR_PROVIDER_EXTENSION_DEBUG_FILE`
+
+### Fallback models
+
+- Static `cursor-models-raw.json` file for pre-login model availability
+
+## Testing Decisions
+
+Good tests for this feature set test **external behavior through module interfaces**, not internal implementation details. They should be deterministic, fast, and not require network access or a real Cursor subscription.
+
+### Modules to test
+
+- **Model normalization** (`parseModelId`, `processModels`, `buildEffortMap`, `resolveModelId`, `supportsReasoningModelId`) — pure functions, high value. Port and extend the upstream test suite. Cover edge cases: triple-max model IDs, xhigh+max coexistence, single-effort collapse, codex-max base names.
+- **Config** (`loadConfig`, `saveConfig`, `resolveEffective`) — env override precedence, version migration, malformed file handling, unknown fields.
+- **Checkpoint lineage** (`computeLineageFingerprint`, `validateLineage`, `shouldDiscardCheckpoint`) — turn count mismatch, fingerprint mismatch, same-depth fork, compaction scenario.
+- **Native tool execution** — path sandboxing enforcement, allowed-root boundary, each tool's execute+format cycle.
+- **Native tools routing** — mode-aware dispatch for all three modes (extend existing `tool-gating.test.ts` and `native-tools.test.ts`).
+- **Message parsing** — image content part preservation (extend existing `openai-messages.test.ts`).
+
+### Prior art
+
+- `packages/pi-cursor/src/proxy/tool-gating.test.ts` — comprehensive exec message routing tests
+- `packages/pi-cursor/src/proxy/native-tools.test.ts` — tool classification and enabled-set tests
+- `packages/pi-cursor/src/proxy/openai-messages.test.ts` — message parsing tests
+- `packages/pi-cursor/src/proxy/conversation-state.test.ts` — state persistence tests
+
+## Out of Scope
+
+- Per-token cost tracking (Cursor is subscription-based; zeros are honest)
+- Periodic model refresh polling (explicit action or restart only)
+- Implementation of all remaining Cursor tools (`backgroundShellSpawn`, `webSearch`, `exaSearch`, `askQuestion`, `switchMode`, `createPlan`) — these reject clearly for now
+- Nested/hierarchical settings menus
+- Per-session or per-project config overrides (config is global only)
+- Conversation state persistence to disk across proxy restarts (checkpoints are in-memory with disk cache; full durability is a separate concern)
+
+## Further Notes
+
+- This is a **breaking change**: default `nativeToolsMode` shifts from implicit redirect to explicit `reject`. Acceptable pre-1.0.
+- The upstream repo ([ndraiman/pi-cursor-provider](https://github.com/ndraiman/pi-cursor-provider)) has a stale fallback model file (83 models vs 169+ in real Cursor data). The real data reveals that `xhigh` and `max` effort suffixes coexist and that trailing `-max` is a universal maxMode flag, not an effort level.
+- Session compaction breakage is the most user-visible bug fixed by this work. The root cause is content-based key derivation; the fix is session-ID-based key derivation.


### PR DESCRIPTION
## Summary

Design documentation for the upcoming  settings command, model normalization, and session correctness feature set.

### Changes

- **CONTEXT.md** — Updated domain glossary with new terms: Model Normalization, Effort Map, Effort Resolution, Max Mode, Native Tools Mode, Overlapping/Remaining Tools, Allowed Root, Checkpoint Lineage, Cursor Config, `/cursor` Command, Fallback Models. Corrected the three meanings of `max` in Cursor model IDs.
- **ADR-0004** — Session identity from Pi session ID (fixes session compaction breakage)
- **ADR-0005** — Three-mode native tools policy (reject/redirect/native)
- **ADR-0006** — Model normalization with effort mapping (correct trailing `-max` parsing, xhigh+max coexistence)
- **ADR-0007** — Global cursor config with environment variable override
- **ADR-0008** — Checkpoint lineage for fork and compaction safety
- **PRD** — Full product requirements document covering all 21 features

### Key design decisions

- `/cursor` command with single-level settings menu
- Persistent global config at `~/.pi/agent/cursor-config.json` (versioned, env overrides win)
- Default `nativeToolsMode=reject` (breaking change, acceptable pre-1.0)
- Model dedup: parser strips trailing `-max` (maxMode), `-fast`, `-thinking`, then effort — all three `max` meanings are independent
- Session keys derived from stable Pi session ID, not message content
- Checkpoint lineage validation (turn count + fingerprint) for fork/compaction safety

Closes #12