### PR TITLE
fix: preserve blob store across compaction and skip pi_session_id for non-cursor providers

### DIFF
--- a/.changeset/fix-blob-compaction-vertex.md
+++ b/.changeset/fix-blob-compaction-vertex.md
@@ -1,0 +1,23 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+fix: preserve blob store across compaction and skip pi_session_id for non-cursor providers
+
+**Blob/compaction fix:**
+
+- Stop clearing `blobStore` on lineage invalidation (compaction, fork, branch switch). Cursor's server may still reference blobs by conversationId after a fresh rebuild, so clearing caused "Blob not found" errors after compaction.
+- Extract `discardCheckpoint()` helper in `conversation-state.ts` for the checkpoint-only invalidation pattern.
+- Add `pruneBlobs()` with LRU eviction at 128-blob cap to prevent unbounded growth across compaction cycles.
+- Fix `blob_not_found` retry to rebuild `requestBytes` without the stale checkpoint via a `rebuildWithoutCheckpoint` callback on `RetryContext`, so the retry actually recovers instead of resending the same broken request.
+- Remove no-op blob sync loop in `onCheckpoint` (shared Map reference made it a no-op).
+
+**Vertex provider fix:**
+
+- Only inject `pi_session_id` and `pi_cwd` into request body when `provider === 'cursor'`. Other providers (anthropic-vertex, openai, etc.) send requests directly to their API and reject unknown fields with `400 pi_session_id: Extra inputs are not permitted`.
+- Guard is fail-closed: if `ctx.model` is undefined, injection is skipped.
+
+**Diagnostics:**
+
+- Add `logLineageInvalidation()` debug event with turn counts and blob count.
+- Add `console.warn` on `GetBlob` cache miss with key prefix and store size.

--- a/packages/pi-cursor/src/index.ts
+++ b/packages/pi-cursor/src/index.ts
@@ -344,8 +344,14 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     logLifecycle(sessionId, '', { event: 'session_start' })
   })
 
-  // Inject pi_session_id and pi_cwd into every provider request body
+  // Inject pi_session_id and pi_cwd only when the request is routed through the
+  // pi-cursor proxy (provider === 'cursor').  Other providers (anthropic-vertex,
+  // openai, etc.) send requests directly to their API and reject unknown fields.
   pi.on('before_provider_request', (event, ctx) => {
+    const currentModel = ctx.model
+    if (currentModel?.provider !== 'cursor') {
+      return event.payload
+    }
     const { payload } = event
     if (typeof payload === 'object' && payload !== null) {
       ;(payload as Record<string, unknown>).pi_session_id = sessionId

--- a/packages/pi-cursor/src/proxy/conversation-state.test.ts
+++ b/packages/pi-cursor/src/proxy/conversation-state.test.ts
@@ -6,8 +6,10 @@ import { describe, it, beforeEach, afterEach, expect } from 'vitest'
 
 import {
   computeLineageFingerprint,
+  discardCheckpoint,
   invalidateConversationState,
   persistConversation,
+  pruneBlobs,
   resolveConversationState,
   validateLineage,
   type StoredConversation,
@@ -154,6 +156,71 @@ describe('validateLineage — checkpoint discard scenarios', () => {
       lineageFingerprint: 'abc',
     })
     expect(validateLineage(stored, { turnCount: 3, fingerprint: 'abc' })).toBeTruthy()
+  })
+
+  it('discardCheckpoint preserves blobStore (compaction scenario)', () => {
+    const blobStore = new Map<string, Uint8Array>()
+    blobStore.set('blob-key-1', new Uint8Array([10, 20, 30]))
+    blobStore.set('blob-key-2', new Uint8Array([40, 50, 60]))
+
+    const stored = makeStored({
+      checkpoint: new Uint8Array([1, 2, 3]),
+      lineageTurnCount: 5,
+      lineageFingerprint: 'pre-compaction',
+      blobStore,
+      checkpointHistory: new Map([['h1', new Uint8Array([1])]]),
+      checkpointArchive: new Map([['a1', new Uint8Array([2])]]),
+    })
+
+    // Lineage mismatch (compaction reduced turns)
+    expect(validateLineage(stored, { turnCount: 1, fingerprint: 'post-compaction' })).toBeFalsy()
+
+    // Use the actual helper used by main.ts
+    discardCheckpoint(stored)
+
+    // Checkpoint + history cleared, blobs preserved
+    expect(stored.checkpoint).toBeNull()
+    expect(stored.checkpointHistory.size).toBe(0)
+    expect(stored.checkpointArchive.size).toBe(0)
+    expect(stored.blobStore.size).toBe(2)
+    expect(stored.blobStore.get('blob-key-1')).toEqual(new Uint8Array([10, 20, 30]))
+    expect(stored.blobStore.get('blob-key-2')).toEqual(new Uint8Array([40, 50, 60]))
+  })
+})
+
+describe('pruneBlobs', () => {
+  it('does nothing when under the cap', () => {
+    const store = new Map<string, Uint8Array>()
+    store.set('a', new Uint8Array([1]))
+    store.set('b', new Uint8Array([2]))
+    expect(pruneBlobs(store)).toBe(0)
+    expect(store.size).toBe(2)
+  })
+
+  it('evicts oldest entries when over the cap', () => {
+    const store = new Map<string, Uint8Array>()
+    // Fill to 130 (cap is 128)
+    for (let i = 0; i < 130; i++) {
+      store.set(`key-${String(i).padStart(3, '0')}`, new Uint8Array([i]))
+    }
+    expect(store.size).toBe(130)
+    const evicted = pruneBlobs(store)
+    expect(evicted).toBe(2)
+    expect(store.size).toBe(128)
+    // Oldest two (key-000, key-001) should be gone
+    expect(store.has('key-000')).toBeFalsy()
+    expect(store.has('key-001')).toBeFalsy()
+    // Newest should remain
+    expect(store.has('key-129')).toBeTruthy()
+  })
+
+  it('handles exact cap boundary', () => {
+    const store = new Map<string, Uint8Array>()
+    for (let i = 0; i < 128; i++) {
+      store.set(`k${i}`, new Uint8Array([i]))
+    }
+    expect(pruneBlobs(store)).toBe(0)
+    expect(store.size).toBe(128)
   })
 })
 

--- a/packages/pi-cursor/src/proxy/conversation-state.ts
+++ b/packages/pi-cursor/src/proxy/conversation-state.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path'
 
 import type { ParsedConversationTurn } from './openai-messages.ts'
 
+/** Maximum number of blobs retained per conversation. LRU-evicted on overflow. */
+const MAX_BLOB_COUNT = 128
+
 export interface StoredConversation {
   conversationId: string
   checkpoint: Uint8Array | null
@@ -180,6 +183,38 @@ export function validateLineage(stored: StoredConversation, incoming: LineageMet
     return true
   }
   return stored.lineageFingerprint === incoming.fingerprint
+}
+
+/**
+ * Discard checkpoint and history but preserve blobStore.
+ * Use on lineage mismatch (compaction, fork, branch switch) so that
+ * Cursor can still GetBlob for previously-stored data after a fresh rebuild.
+ */
+export function discardCheckpoint(stored: StoredConversation): void {
+  stored.checkpoint = null
+  stored.checkpointHistory.clear()
+  stored.checkpointArchive.clear()
+}
+
+/**
+ * Evict oldest blobs when the store exceeds MAX_BLOB_COUNT.
+ * Map iteration order is insertion-order, so deleting from the front
+ * evicts the oldest entries first (LRU approximation).
+ */
+export function pruneBlobs(blobStore: Map<string, Uint8Array>): number {
+  const excess = blobStore.size - MAX_BLOB_COUNT
+  if (excess <= 0) {
+    return 0
+  }
+  let evicted = 0
+  for (const key of blobStore.keys()) {
+    if (evicted >= excess) {
+      break
+    }
+    blobStore.delete(key)
+    evicted++
+  }
+  return evicted
 }
 
 /**

--- a/packages/pi-cursor/src/proxy/cursor-messages.ts
+++ b/packages/pi-cursor/src/proxy/cursor-messages.ts
@@ -406,6 +406,11 @@ function handleKvMessage(
     const { blobId } = kvMsg.message.value
     const blobIdKey = Buffer.from(blobId).toString('hex')
     const blobData = blobStore.get(blobIdKey)
+    if (!blobData) {
+      console.warn(
+        `[cursor-messages] GetBlob miss: key=${blobIdKey.slice(0, 16)}... (store has ${blobStore.size} blobs)`,
+      )
+    }
     sendKvResponse(kvMsg, 'getBlobResult', create(GetBlobResultSchema, blobData ? { blobData } : {}), sendFrame)
   } else if (kvCase === 'setBlobArgs') {
     const { blobId, blobData } = kvMsg.message.value

--- a/packages/pi-cursor/src/proxy/cursor-session.ts
+++ b/packages/pi-cursor/src/proxy/cursor-session.ts
@@ -73,7 +73,7 @@ export interface SessionOptions {
   nativeToolsMode: NativeToolsMode
   allowedRoot?: string
   convKey: string
-  onCheckpoint?: (bytes: Uint8Array, blobStore: Map<string, Uint8Array>) => void
+  onCheckpoint?: (bytes: Uint8Array) => void
 }
 
 function classifyConnectError(errorMessage: string): RetryHint | undefined {
@@ -528,7 +528,7 @@ export class CursorSession {
         onCheckpoint: (checkpointBytes) => {
           this._checkpointChunkSeq = this._chunkSeq
           this.streamState.checkpointAfterExec = true
-          this.options.onCheckpoint?.(checkpointBytes, this.blobStore)
+          this.options.onCheckpoint?.(checkpointBytes)
         },
         onNotify: (note) => {
           this.queue.push({ type: 'text', text: `\n${note}\n`, isThinking: false })

--- a/packages/pi-cursor/src/proxy/debug-logger.ts
+++ b/packages/pi-cursor/src/proxy/debug-logger.ts
@@ -24,6 +24,7 @@ type DebugEventType =
   | 'tool_call'
   | 'bridge_open'
   | 'bridge_close'
+  | 'lineage_invalidation'
   | 'lifecycle'
 
 interface DebugLogEntry {
@@ -222,6 +223,26 @@ export function logRetry(
     attempt: payload.attempt,
     hint: payload.hint,
     delayMs: payload.delayMs,
+  })
+}
+
+/** Log lineage invalidation (compaction, fork, branch switch). */
+export function logLineageInvalidation(
+  sessionId: string,
+  requestId: string,
+  payload: { storedTurnCount: number; incomingTurnCount: number; blobCount: number },
+): void {
+  if (!_enabled) {
+    return
+  }
+  writeEntry({
+    timestamp: new Date().toISOString(),
+    type: 'lineage_invalidation',
+    sessionId,
+    requestId,
+    storedTurnCount: payload.storedTurnCount,
+    incomingTurnCount: payload.incomingTurnCount,
+    blobCount: payload.blobCount,
   })
 }
 

--- a/packages/pi-cursor/src/proxy/main.ts
+++ b/packages/pi-cursor/src/proxy/main.ts
@@ -44,12 +44,16 @@ import {
   validateLineage,
   type ConversationConfig,
   type LineageMetadata,
+  type StoredConversation,
+  discardCheckpoint,
   evictStaleConversations,
+  pruneBlobs,
 } from './conversation-state.ts'
 import { CursorSession, type RetryHint, type SessionOptions } from './cursor-session.ts'
 import {
   debugRequestId,
   logCheckpointCommit,
+  logLineageInvalidation,
   logRequestEnd,
   logRequestStart,
   logRetry,
@@ -431,10 +435,13 @@ async function handleChatCompletion(
     fingerprint: computeLineageFingerprint(turns),
   }
   if (stored.checkpoint !== null && !validateLineage(stored, incomingLineage)) {
-    stored.checkpoint = null
-    stored.checkpointHistory.clear()
-    stored.checkpointArchive.clear()
-    stored.blobStore.clear()
+    logLineageInvalidation(sessionId, requestId, {
+      storedTurnCount: stored.lineageTurnCount,
+      incomingTurnCount: incomingLineage.turnCount,
+      blobCount: stored.blobStore.size,
+    })
+    discardCheckpoint(stored)
+    // blobStore is intentionally preserved — see discardCheckpoint() docs.
   }
 
   const effectiveUserText = userText || (toolResults.length > 0 ? toolResults.map((r) => r.content).join('\n') : '')
@@ -460,12 +467,12 @@ async function handleChatCompletion(
     nativeToolsMode: cfg.nativeToolsMode,
     allowedRoot,
     convKey,
-    onCheckpoint: (checkpointBytes, blobStoreRef) => {
+    onCheckpoint: (checkpointBytes) => {
       stored.checkpoint = checkpointBytes
-      // Sync blob store reference
-      for (const [k, v] of blobStoreRef) {
-        stored.blobStore.set(k, v)
-      }
+      // blobStore is a shared Map reference — SetBlob mutations from
+      // handleKvMessage are already visible in stored.blobStore.
+      // Prune oldest blobs if the store exceeds the size cap.
+      pruneBlobs(stored.blobStore)
       persistConversation(convKey, stored, convConfig)
       logCheckpointCommit(sessionId, requestId, { sizeBytes: checkpointBytes.length })
     },
@@ -501,7 +508,23 @@ async function handleChatCompletion(
             rid: requestId,
             startTime: requestStartTime,
           },
-          { sessionOptions, req, maxRetries: cfg.maxRetries },
+          {
+            sessionOptions,
+            req,
+            maxRetries: cfg.maxRetries,
+            rebuildWithoutCheckpoint: (s) =>
+              buildCursorRequest(
+                modelId,
+                systemPrompt,
+                effectiveUserText,
+                turns,
+                s.conversationId,
+                null,
+                s.blobStore,
+                mcpTools,
+                cfg.nativeToolsMode,
+              ).requestBytes,
+          },
         )
       },
     })
@@ -567,6 +590,8 @@ interface RetryContext {
   sessionOptions: SessionOptions
   req: IncomingMessage
   maxRetries: number
+  /** Rebuild requestBytes without checkpoint for blob_not_found recovery. */
+  rebuildWithoutCheckpoint?: (stored: StoredConversation) => Uint8Array
 }
 
 /**
@@ -613,7 +638,26 @@ async function pumpAndFinalize(
         )
         await sleep(delayMs)
 
-        // New session with the same options — checkpoint preserves conversation state
+        // On blob_not_found: discard the stale checkpoint and rebuild
+        // requestBytes so the retry sends a fresh conversation to Cursor.
+        // The blobStore is preserved — old blobs may still be needed.
+        if (result.retryHint === 'blob_not_found') {
+          const stored = getConversationState(convKey)
+          if (stored?.checkpoint) {
+            discardCheckpoint(stored)
+            if (retryCtx.rebuildWithoutCheckpoint) {
+              retryCtx.sessionOptions = {
+                ...retryCtx.sessionOptions,
+                requestBytes: retryCtx.rebuildWithoutCheckpoint(stored),
+              }
+            }
+            persistConversation(convKey, stored, convConfig)
+            console.error('[proxy] blob_not_found: rebuilt request without checkpoint for retry')
+          }
+        }
+
+        // New session — either same options (transient error) or
+        // rebuilt options (blob_not_found checkpoint discard)
         currentSession = new CursorSession(retryCtx.sessionOptions)
         // Remove previous close handler to prevent listener accumulation
         if (streamCloseHandler) {


### PR DESCRIPTION
## Summary

Fixes two bugs in pi-cursor:

1. **"Blob not found" after compaction** — lineage invalidation was clearing the entire `blobStore`, destroying blob data that Cursor's server still expected the client to serve via `GetBlob`.
2. **Anthropic Vertex 400 error** — `pi_session_id` and `pi_cwd` were injected into every provider request body, but non-cursor providers reject unknown fields.

## Changes

### Blob/compaction fix
- **Preserve `blobStore` on lineage invalidation** — only discard checkpoint and history, not blobs. Cursor may still reference blobs by `conversationId` after a fresh rebuild.
- **Extract `discardCheckpoint()` helper** in `conversation-state.ts` for the checkpoint-only invalidation pattern (used in 2 places).
- **Add `pruneBlobs()`** with LRU eviction at 128-blob cap to prevent unbounded growth across compaction cycles.
- **Fix `blob_not_found` retry** — add `rebuildWithoutCheckpoint` callback to `RetryContext` so the retry rebuilds `requestBytes` without the stale checkpoint instead of resending the same broken request.
- **Remove no-op blob sync loop** in `onCheckpoint` — `blobStoreRef` and `stored.blobStore` are the same `Map` reference, so the loop was a no-op.

### Vertex provider fix
- **Guard `pi_session_id` injection** — only inject when `provider === "cursor"`. Fail-closed: if `ctx.model` is undefined, injection is skipped.

### Diagnostics
- `logLineageInvalidation()` debug event with turn counts and blob count.
- `console.warn` on `GetBlob` cache miss with key prefix and store size.

## Testing
- 205 tests pass (201 existing + 4 new)
- New tests cover `discardCheckpoint()` blob preservation and `pruneBlobs()` eviction behavior
- Clean TypeScript compile, lint, and format

## Files changed
| File | Change |
|------|--------|
| `index.ts` | Provider-aware `pi_session_id` injection |
| `conversation-state.ts` | `discardCheckpoint()`, `pruneBlobs()` |
| `conversation-state.test.ts` | Tests for new helpers |
| `cursor-messages.ts` | GetBlob miss warning |
| `cursor-session.ts` | Simplify `onCheckpoint` signature |
| `debug-logger.ts` | `logLineageInvalidation()` |
| `main.ts` | Blob preservation, retry rebuild, pruning |