### PR TITLE
fix: resolve "Blob not found" errors after compaction by resetting conversation

### DIFF
--- a/.changeset/fix-blob-not-found-compaction.md
+++ b/.changeset/fix-blob-not-found-compaction.md
@@ -1,0 +1,28 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+fix: resolve "Blob not found" errors after compaction by resetting conversation
+
+After Pi compaction, lineage validation detects a mismatch and must rebuild
+the conversation state. Cursor's server treats the `turns` field in
+`ConversationStateStructure` as blob references — not inline data. The old
+code rebuilt turns from scratch with inline protobuf bytes, which Cursor
+tried to look up as blob IDs, causing "Blob not found" errors.
+
+Changes:
+
+- `resetConversation()` (renamed from `discardCheckpoint`) now assigns a new
+  conversation ID and clears the blob store, ensuring Cursor treats the next
+  request as a brand-new conversation with empty turns.
+- `buildCursorRequest()` folds prior turns into the system prompt via
+  `foldTurnsIntoSystemPrompt()` instead of building inline turn protos.
+  A 100KB size cap truncates oldest turns when the combined prompt is too large.
+- Non-streaming retry path now surfaces `retryHint` from
+  `collectNonStreamingResponse` and handles `blob_not_found` with conversation
+  reset + request rebuild (mirrors the streaming retry path).
+- Streaming retry path relaxes the `stored?.checkpoint` guard so
+  `resetConversation` is called unconditionally on `blob_not_found`.
+- Removed 4 dead proto imports no longer needed after the turn-building removal.
+- Added 9 new tests covering turn folding (truncation, edge cases) and
+  conversation reset behavior.

--- a/packages/pi-cursor/src/proxy/conversation-state.test.ts
+++ b/packages/pi-cursor/src/proxy/conversation-state.test.ts
@@ -6,7 +6,7 @@ import { describe, it, beforeEach, afterEach, expect } from 'vitest'
 
 import {
   computeLineageFingerprint,
-  discardCheckpoint,
+  resetConversation,
   invalidateConversationState,
   persistConversation,
   pruneBlobs,
@@ -158,12 +158,13 @@ describe('validateLineage — checkpoint discard scenarios', () => {
     expect(validateLineage(stored, { turnCount: 3, fingerprint: 'abc' })).toBeTruthy()
   })
 
-  it('discardCheckpoint preserves blobStore (compaction scenario)', () => {
+  it('resetConversation resets conversationId, clears checkpoint + blobs (compaction scenario)', () => {
     const blobStore = new Map<string, Uint8Array>()
     blobStore.set('blob-key-1', new Uint8Array([10, 20, 30]))
     blobStore.set('blob-key-2', new Uint8Array([40, 50, 60]))
 
     const stored = makeStored({
+      conversationId: 'original-id',
       checkpoint: new Uint8Array([1, 2, 3]),
       lineageTurnCount: 5,
       lineageFingerprint: 'pre-compaction',
@@ -176,15 +177,33 @@ describe('validateLineage — checkpoint discard scenarios', () => {
     expect(validateLineage(stored, { turnCount: 1, fingerprint: 'post-compaction' })).toBeFalsy()
 
     // Use the actual helper used by main.ts
-    discardCheckpoint(stored)
+    resetConversation(stored)
 
-    // Checkpoint + history cleared, blobs preserved
+    // Conversation ID is reset to a new UUID
+    expect(stored.conversationId).not.toBe('original-id')
+    expect(stored.conversationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+
+    // Checkpoint + history + blobs all cleared (fresh conversation)
     expect(stored.checkpoint).toBeNull()
     expect(stored.checkpointHistory.size).toBe(0)
     expect(stored.checkpointArchive.size).toBe(0)
-    expect(stored.blobStore.size).toBe(2)
-    expect(stored.blobStore.get('blob-key-1')).toEqual(new Uint8Array([10, 20, 30]))
-    expect(stored.blobStore.get('blob-key-2')).toEqual(new Uint8Array([40, 50, 60]))
+    expect(stored.blobStore.size).toBe(0)
+  })
+
+  it('resetConversation on already-clean state (no checkpoint, empty blobs)', () => {
+    const stored = makeStored({
+      conversationId: 'original-id',
+      checkpoint: null,
+      blobStore: new Map(),
+    })
+
+    resetConversation(stored)
+
+    // Conversation ID still changes even if state was already clean
+    expect(stored.conversationId).not.toBe('original-id')
+    expect(stored.conversationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    expect(stored.checkpoint).toBeNull()
+    expect(stored.blobStore.size).toBe(0)
   })
 })
 

--- a/packages/pi-cursor/src/proxy/conversation-state.ts
+++ b/packages/pi-cursor/src/proxy/conversation-state.ts
@@ -186,14 +186,25 @@ export function validateLineage(stored: StoredConversation, incoming: LineageMet
 }
 
 /**
- * Discard checkpoint and history but preserve blobStore.
- * Use on lineage mismatch (compaction, fork, branch switch) so that
- * Cursor can still GetBlob for previously-stored data after a fresh rebuild.
+ * Discard checkpoint, history, and blobs, and assign a new conversation ID.
+ * Use on lineage mismatch (compaction, fork, branch switch).
+ *
+ * A new conversation ID is required because Cursor's server treats the
+ * `turns` field in ConversationStateStructure as blob references, not inline
+ * data.  Rebuilding turns from scratch produces bytes the server tries to
+ * look up via GetBlob, causing "Blob not found" errors.  A fresh ID ensures
+ * the server treats the next request as a brand-new conversation (empty turns)
+ * which always succeeds.
+ *
+ * The blobStore is cleared because old blobs belong to the previous
+ * conversation ID and will never be requested again.
  */
-export function discardCheckpoint(stored: StoredConversation): void {
+export function resetConversation(stored: StoredConversation): void {
+  stored.conversationId = randomUUID()
   stored.checkpoint = null
   stored.checkpointHistory.clear()
   stored.checkpointArchive.clear()
+  stored.blobStore.clear()
 }
 
 /**

--- a/packages/pi-cursor/src/proxy/main.ts
+++ b/packages/pi-cursor/src/proxy/main.ts
@@ -22,13 +22,9 @@ import { ValueSchema } from '@bufbuild/protobuf/wkt'
 
 import {
   AgentClientMessageSchema,
-  AgentConversationTurnStructureSchema,
   AgentRunRequestSchema,
-  AssistantMessageSchema,
   ConversationActionSchema,
   ConversationStateStructureSchema,
-  ConversationStepSchema,
-  ConversationTurnStructureSchema,
   McpToolDefinitionSchema,
   type McpToolDefinition,
   ModelDetailsSchema,
@@ -45,7 +41,7 @@ import {
   type ConversationConfig,
   type LineageMetadata,
   type StoredConversation,
-  discardCheckpoint,
+  resetConversation,
   evictStaleConversations,
   pruneBlobs,
 } from './conversation-state.ts'
@@ -181,6 +177,63 @@ function decodeCheckpointState(
   }
 }
 
+/**
+ * Maximum byte size for the effective system prompt after folding turns.
+ * Older turns are dropped (newest-first) when the combined size exceeds this.
+ */
+const MAX_EFFECTIVE_PROMPT_BYTES = 100_000
+
+/**
+ * Fold prior conversation turns into the system prompt so the LLM retains
+ * context even when no checkpoint is available (e.g. after compaction).
+ *
+ * If the combined size exceeds MAX_EFFECTIVE_PROMPT_BYTES, the oldest turns
+ * are dropped and a note is prepended indicating truncation.
+ */
+export function foldTurnsIntoSystemPrompt(
+  systemPrompt: string,
+  turns: { userText: string; assistantText: string }[],
+): string {
+  if (turns.length === 0) {
+    return systemPrompt
+  }
+
+  const contextParts = turns.map(
+    (t) => `User: ${t.userText}${t.assistantText ? `\nAssistant: ${t.assistantText}` : ''}`,
+  )
+
+  // Try full fold first
+  const fullFold = `${systemPrompt}\n\nPrevious conversation context:\n${contextParts.join('\n\n')}`
+  if (new TextEncoder().encode(fullFold).byteLength <= MAX_EFFECTIVE_PROMPT_BYTES) {
+    return fullFold
+  }
+
+  // Truncate oldest turns until under the cap
+  console.error(
+    `[proxy] Folded system prompt exceeds ${String(MAX_EFFECTIVE_PROMPT_BYTES)} bytes — truncating oldest turns`,
+  )
+  const kept: string[] = []
+  const prefix = `${systemPrompt}\n\nPrevious conversation context (oldest turns truncated):\n`
+  let budget = MAX_EFFECTIVE_PROMPT_BYTES - new TextEncoder().encode(prefix).byteLength
+
+  // Walk from newest to oldest, keeping what fits
+  for (let i = contextParts.length - 1; i >= 0; i--) {
+    const partBytes = new TextEncoder().encode(contextParts[i]).byteLength + 2 // +2 for '\n\n' separator
+    if (partBytes > budget) {
+      break
+    }
+    budget -= partBytes
+    kept.unshift(contextParts[i])
+  }
+
+  if (kept.length === 0) {
+    // Even one turn doesn't fit — just return the system prompt
+    return systemPrompt
+  }
+
+  return `${prefix}${kept.join('\n\n')}`
+}
+
 function buildCursorRequest(
   modelId: string,
   systemPrompt: string,
@@ -196,46 +249,28 @@ function buildCursorRequest(
   const decodedCheckpoint = checkpoint ? decodeCheckpointState(checkpoint) : null
 
   let conversationState: ReturnType<typeof create<typeof ConversationStateStructureSchema>>
+  let effectiveSystemPrompt = systemPrompt
+
   if (decodedCheckpoint) {
     conversationState = decodedCheckpoint
   } else {
-    // Build turns from scratch
-    const turnBytes: Uint8Array[] = []
-    for (const turn of turns) {
-      const userMsg = create(UserMessageSchema, {
-        text: turn.userText,
-        messageId: randomUUID(),
-      })
-      const userMsgBytes = toBinary(UserMessageSchema, userMsg)
-
-      const stepBytes: Uint8Array[] = []
-      if (turn.assistantText) {
-        const step = create(ConversationStepSchema, {
-          message: {
-            case: 'assistantMessage',
-            value: create(AssistantMessageSchema, { text: turn.assistantText }),
-          },
-        })
-        stepBytes.push(toBinary(ConversationStepSchema, step))
-      }
-
-      const agentTurn = create(AgentConversationTurnStructureSchema, {
-        userMessage: userMsgBytes,
-        steps: stepBytes,
-      })
-      const turnStructure = create(ConversationTurnStructureSchema, {
-        turn: { case: 'agentConversationTurn', value: agentTurn },
-      })
-      turnBytes.push(toBinary(ConversationTurnStructureSchema, turnStructure))
+    // No checkpoint — start a fresh conversation with empty turns.
+    //
+    // Cursor's server treats the `turns` field as blob references (not inline
+    // data).  Putting serialized turn bytes there causes "Blob not found"
+    // errors.  Instead, fold any prior turns into the system prompt so the
+    // LLM still sees the conversation context.
+    if (turns.length > 0) {
+      effectiveSystemPrompt = foldTurnsIntoSystemPrompt(systemPrompt, turns)
     }
-    conversationState = create(ConversationStateStructureSchema, { turns: turnBytes })
+    conversationState = create(ConversationStateStructureSchema, { turns: [] })
   }
 
   const userMessage = create(UserMessageSchema, {
     text: userText,
     messageId: randomUUID(),
   })
-  const requestContext = buildRequestContext(mcpTools, systemPrompt || undefined, nativeToolsMode)
+  const requestContext = buildRequestContext(mcpTools, effectiveSystemPrompt || undefined, nativeToolsMode)
   const action = create(ConversationActionSchema, {
     action: {
       case: 'userMessageAction',
@@ -403,7 +438,7 @@ async function handleChatCompletion(
         const reader = readableStream.getReader() as ReadableStreamDefaultReader<Uint8Array>
         void pipeReaderToResponse(reader, res)
       } else {
-        const response = await collectNonStreamingResponse(existingSession, modelId)
+        const { response } = await collectNonStreamingResponse(existingSession, modelId)
         // Update lineage after successful tool-result turn completion
         const stored = getConversationState(convKey)
         if (stored && response.ok) {
@@ -429,7 +464,7 @@ async function handleChatCompletion(
 
   // ── Lineage validation ──
   // Compute incoming lineage from completed turns and validate against stored lineage.
-  // On mismatch (fork, compaction, branch switch), discard the stale checkpoint.
+  // On mismatch (fork, compaction, branch switch), reset the conversation.
   const incomingLineage: LineageMetadata = {
     turnCount: turns.length,
     fingerprint: computeLineageFingerprint(turns),
@@ -440,8 +475,7 @@ async function handleChatCompletion(
       incomingTurnCount: incomingLineage.turnCount,
       blobCount: stored.blobStore.size,
     })
-    discardCheckpoint(stored)
-    // blobStore is intentionally preserved — see discardCheckpoint() docs.
+    resetConversation(stored)
   }
 
   const effectiveUserText = userText || (toolResults.length > 0 ? toolResults.map((r) => r.content).join('\n') : '')
@@ -535,20 +569,41 @@ async function handleChatCompletion(
     // ── Non-streaming with retry ──
     let nonStreamAttempt = 0
     let currentNonStreamSession = session
-    let response: Response
+    let currentNonStreamOptions = sessionOptions
+    let result = await collectNonStreamingResponse(currentNonStreamSession, modelId)
     let nonStreamCloseHandler: (() => void) | null = null
-    for (;;) {
-      response = await collectNonStreamingResponse(currentNonStreamSession, modelId)
-      if (response.ok || nonStreamAttempt >= cfg.maxRetries) {
-        break
-      }
+    while (!result.response.ok && nonStreamAttempt < cfg.maxRetries) {
       nonStreamAttempt++
-      const hint: RetryHint = response.status === 429 ? 'resource_exhausted' : 'timeout'
+      const hint: RetryHint = result.retryHint ?? (result.response.status === 429 ? 'resource_exhausted' : 'timeout')
       const delayMs = retryDelayMs(hint)
       logRetry(sessionId, requestId, { attempt: nonStreamAttempt, hint, delayMs })
-      console.error(`[proxy] Non-streaming retry ${nonStreamAttempt}/${cfg.maxRetries} (status ${response.status})`)
+      console.error(
+        `[proxy] Non-streaming retry ${nonStreamAttempt}/${cfg.maxRetries} (status ${result.response.status})`,
+      )
       await sleep(delayMs)
-      currentNonStreamSession = new CursorSession(sessionOptions)
+
+      // On blob_not_found: reset conversation and rebuild request (mirrors streaming path)
+      if (hint === 'blob_not_found') {
+        resetConversation(stored)
+        currentNonStreamOptions = {
+          ...currentNonStreamOptions,
+          requestBytes: buildCursorRequest(
+            modelId,
+            systemPrompt,
+            effectiveUserText,
+            turns,
+            stored.conversationId,
+            null,
+            stored.blobStore,
+            mcpTools,
+            cfg.nativeToolsMode,
+          ).requestBytes,
+        }
+        persistConversation(convKey, stored, convConfig)
+        console.error('[proxy] blob_not_found: rebuilt non-streaming request with new conversation ID for retry')
+      }
+
+      currentNonStreamSession = new CursorSession(currentNonStreamOptions)
       // Remove previous close handler to prevent listener accumulation
       if (nonStreamCloseHandler) {
         req.removeListener('close', nonStreamCloseHandler)
@@ -560,7 +615,9 @@ async function handleChatCompletion(
         }
       }
       req.on('close', nonStreamCloseHandler)
+      result = await collectNonStreamingResponse(currentNonStreamSession, modelId)
     }
+    const { response } = result
     // Update lineage after successful non-streaming turn completion
     if (response.ok) {
       const completedTurns = [...turns, { userText: effectiveUserText }]
@@ -638,13 +695,14 @@ async function pumpAndFinalize(
         )
         await sleep(delayMs)
 
-        // On blob_not_found: discard the stale checkpoint and rebuild
-        // requestBytes so the retry sends a fresh conversation to Cursor.
-        // The blobStore is preserved — old blobs may still be needed.
+        // On blob_not_found: reset conversation (new ID, clear blobs) and
+        // rebuild requestBytes so the retry starts a fresh Cursor conversation.
+        // Called unconditionally (not guarded by stored?.checkpoint) because
+        // the new conversation ID is needed regardless of checkpoint state.
         if (result.retryHint === 'blob_not_found') {
           const stored = getConversationState(convKey)
-          if (stored?.checkpoint) {
-            discardCheckpoint(stored)
+          if (stored) {
+            resetConversation(stored)
             if (retryCtx.rebuildWithoutCheckpoint) {
               retryCtx.sessionOptions = {
                 ...retryCtx.sessionOptions,
@@ -652,7 +710,7 @@ async function pumpAndFinalize(
               }
             }
             persistConversation(convKey, stored, convConfig)
-            console.error('[proxy] blob_not_found: rebuilt request without checkpoint for retry')
+            console.error('[proxy] blob_not_found: rebuilt request with new conversation ID for retry')
           }
         }
 

--- a/packages/pi-cursor/src/proxy/openai-stream.ts
+++ b/packages/pi-cursor/src/proxy/openai-stream.ts
@@ -330,7 +330,15 @@ function nonStreamingErrorResponse(message: string, code = 'non_streaming_error'
  * Collect all events from a CursorSession and return a complete
  * non-streaming chat.completion response (for `stream: false` requests).
  */
-export async function collectNonStreamingResponse(session: CursorSession, modelId: string): Promise<Response> {
+export interface NonStreamingResult {
+  response: Response
+  retryHint?: RetryHint
+}
+
+export async function collectNonStreamingResponse(
+  session: CursorSession,
+  modelId: string,
+): Promise<NonStreamingResult> {
   const tagFilter = createThinkingTagFilter()
   let text = ''
   let usage: OpenAIUsage | null = null
@@ -349,16 +357,21 @@ export async function collectNonStreamingResponse(session: CursorSession, modelI
       usage = pickBetterUsage(usage, buildUsage(event.outputTokens, event.totalTokens))
     } else if (event.type === 'toolCall' || event.type === 'batchReady') {
       finalizeSession()
-      return nonStreamingErrorResponse(
-        'Unexpected tool activity while collecting a non-streaming response',
-        'unexpected_tool_activity',
-      )
+      return {
+        response: nonStreamingErrorResponse(
+          'Unexpected tool activity while collecting a non-streaming response',
+          'unexpected_tool_activity',
+        ),
+      }
     } else if (event.type === 'done') {
       if (event.retryHint || event.error) {
         finalizeSession()
-        return nonStreamingErrorResponse(
-          event.error ?? 'Cursor session ended before a non-streaming response was complete',
-        )
+        return {
+          response: nonStreamingErrorResponse(
+            event.error ?? 'Cursor session ended before a non-streaming response was complete',
+          ),
+          retryHint: event.retryHint,
+        }
       }
       text += tagFilter.flush().content
       break
@@ -367,15 +380,17 @@ export async function collectNonStreamingResponse(session: CursorSession, modelI
 
   finalizeSession()
 
-  return new Response(
-    JSON.stringify({
-      id: `chatcmpl-${generateCompletionId()}`,
-      object: 'chat.completion',
-      created: Math.floor(Date.now() / 1000),
-      model: modelId,
-      choices: [{ index: 0, message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
-      ...(usage ? { usage } : {}),
-    }),
-    { headers: { 'Content-Type': 'application/json' } },
-  )
+  return {
+    response: new Response(
+      JSON.stringify({
+        id: `chatcmpl-${generateCompletionId()}`,
+        object: 'chat.completion',
+        created: Math.floor(Date.now() / 1000),
+        model: modelId,
+        choices: [{ index: 0, message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
+        ...(usage ? { usage } : {}),
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    ),
+  }
 }

--- a/packages/pi-cursor/src/proxy/request-builder.test.ts
+++ b/packages/pi-cursor/src/proxy/request-builder.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { foldTurnsIntoSystemPrompt } from './main.ts'
+
+describe('foldTurnsIntoSystemPrompt', () => {
+  it('returns original system prompt when turns is empty', () => {
+    const result = foldTurnsIntoSystemPrompt('You are helpful', [])
+    expect(result).toBe('You are helpful')
+  })
+
+  it('folds a single turn with both user and assistant text', () => {
+    const result = foldTurnsIntoSystemPrompt('Be concise', [{ userText: 'hello', assistantText: 'hi there' }])
+    expect(result).toContain('Previous conversation context:')
+    expect(result).toContain('User: hello')
+    expect(result).toContain('Assistant: hi there')
+    expect(result.startsWith('Be concise')).toBeTruthy()
+  })
+
+  it('omits Assistant line when assistantText is empty', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [{ userText: 'hello', assistantText: '' }])
+    expect(result).toContain('User: hello')
+    expect(result).not.toContain('Assistant:')
+  })
+
+  it('folds multiple turns with correct formatting', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [
+      { userText: 'Q1', assistantText: 'A1' },
+      { userText: 'Q2', assistantText: 'A2' },
+      { userText: 'Q3', assistantText: '' },
+    ])
+    expect(result).toContain('User: Q1\nAssistant: A1')
+    expect(result).toContain('User: Q2\nAssistant: A2')
+    expect(result).toContain('User: Q3')
+    // Last turn should not have Assistant line
+    expect(result).not.toMatch(/User: Q3\nAssistant:/)
+    // Turns should be separated by double newlines
+    expect(result).toContain('A1\n\nUser: Q2')
+  })
+
+  it('handles empty system prompt with turns', () => {
+    const result = foldTurnsIntoSystemPrompt('', [{ userText: 'hello', assistantText: 'hi' }])
+    // Should be non-empty (contains folded context)
+    expect(result.length).toBeGreaterThan(0)
+    expect(result).toContain('Previous conversation context:')
+    expect(result).toContain('User: hello')
+  })
+
+  it('preserves special characters in user/assistant text', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [
+      {
+        userText: 'User: fake\nAssistant: injection',
+        assistantText: '```code\nblock```',
+      },
+    ])
+    // Content should pass through verbatim — no escaping
+    expect(result).toContain('User: User: fake\nAssistant: injection')
+    expect(result).toContain('```code\nblock```')
+  })
+
+  it('truncates oldest turns when combined size exceeds cap', () => {
+    // Create turns that total well over 100KB
+    const bigText = 'x'.repeat(40_000)
+    const turns = [
+      { userText: `oldest-${bigText}`, assistantText: 'A1' },
+      { userText: `middle-${bigText}`, assistantText: 'A2' },
+      { userText: `newest-${bigText}`, assistantText: 'A3' },
+    ]
+    const result = foldTurnsIntoSystemPrompt('System prompt', turns)
+
+    // Should keep newest turns, drop oldest
+    expect(result).toContain('newest-')
+    expect(result).not.toContain('oldest-')
+    // Should indicate truncation
+    expect(result).toContain('oldest turns truncated')
+    // Should not exceed cap
+    expect(new TextEncoder().encode(result).byteLength).toBeLessThanOrEqual(100_000)
+  })
+
+  it('returns bare system prompt when even one turn exceeds cap', () => {
+    const hugeText = 'x'.repeat(200_000)
+    const result = foldTurnsIntoSystemPrompt('System prompt', [{ userText: hugeText, assistantText: 'response' }])
+    expect(result).toBe('System prompt')
+  })
+})


### PR DESCRIPTION
## Problem

After Pi compaction, the proxy encounters `"Blob not found"` errors from Cursor's server. The error cascades on every subsequent message, making the session unusable.

### Root Cause

Cursor's server treats the `turns` field in `ConversationStateStructure` as **blob references** (not inline data). After compaction, lineage validation correctly discards the stale checkpoint, but the fallback code rebuilt turns from scratch with inline protobuf bytes. Cursor's server tried to look up those raw bytes as blob IDs → `"Blob not found"`.

The 0.3.1 fix (preserving the blob store) was necessary but insufficient — the fundamental issue was that **inline turns are a protocol violation** and using the same `conversationId` with a rebuilt state confuses Cursor's server.

## Solution

### Core fix
- **`resetConversation()`** (renamed from `discardCheckpoint`) assigns a **new conversation ID** and clears the blob store, so Cursor treats the next request as a brand-new conversation
- **`foldTurnsIntoSystemPrompt()`** embeds prior conversation turns into the system prompt instead of building inline turn protos — sends `turns: []` (first-turn behavior that always works)

### Hardening (from review feedback)
- **Non-streaming retry**: `collectNonStreamingResponse` now surfaces `retryHint`; the non-streaming retry loop handles `blob_not_found` with conversation reset + rebuild (mirrors streaming path)
- **Streaming retry**: Relaxed `stored?.checkpoint` guard so `resetConversation` fires unconditionally on `blob_not_found` (prevents wasted retries when checkpoint is already null)
- **Size cap**: `foldTurnsIntoSystemPrompt()` truncates oldest turns when combined prompt exceeds 100KB, with a warning log

### Cleanup
- Removed 4 dead proto imports (`AgentConversationTurnStructureSchema`, `AssistantMessageSchema`, `ConversationStepSchema`, `ConversationTurnStructureSchema`)
- Renamed `discardCheckpoint` → `resetConversation` across all call sites, tests, and comments

## Testing

- **214 tests passing** (was 205, +9 new)
- New `request-builder.test.ts`: 8 tests for `foldTurnsIntoSystemPrompt` (empty turns, single/multi turn, empty assistantText, empty systemPrompt, special chars, truncation at cap, extreme size fallback)
- Updated `conversation-state.test.ts`: verified `resetConversation` resets UUID + clears blobs; added clean-state edge case test
- Lint clean, build clean

## Files changed (5 files, +299/−84)

| File | Change |
|------|--------|
| `conversation-state.ts` | `resetConversation()`: new UUID + clear blobs + checkpoint |
| `main.ts` | `foldTurnsIntoSystemPrompt()` with 100KB cap; non-streaming `blob_not_found` recovery; relaxed retry guard |
| `openai-stream.ts` | `NonStreamingResult` type surfaces `retryHint` |
| `conversation-state.test.ts` | Updated + new tests for `resetConversation` |
| `request-builder.test.ts` | 8 new tests for turn folding |
