### PR TITLE
fix: detect compaction turns and wrap in <context> tags during fold

### DIFF
--- a/.changeset/compaction-turn-detection.md
+++ b/.changeset/compaction-turn-detection.md
@@ -1,0 +1,18 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Fix chat history contamination after compaction
+
+After compaction or branch summary injection, the proxy's `foldTurnsIntoSystemPrompt` now
+detects compaction/branch summary turns and wraps them in `<context>` XML tags instead of
+labeling them as `User:` messages. This prevents the model from treating compaction summaries
+as real user messages when reporting chat history.
+
+- Added `isCompaction` field to `ParsedConversationTurn` with `startsWith` detection against
+  pi-core's known `COMPACTION_SUMMARY_PREFIX` and `BRANCH_SUMMARY_PREFIX` markers
+- Compaction turns are wrapped in `<context>...</context>` tags (assistant acknowledgments dropped)
+- Regular turns keep the existing `User:` / `Assistant:` format
+- Updated `buildCursorRequest` type signature to explicitly pass `isCompaction` through
+- Truncation now prioritizes compaction turns — they are reserved first so pre-compaction
+  context survives when the prompt exceeds the 100KB cap

--- a/packages/pi-cursor/src/proxy/main.ts
+++ b/packages/pi-cursor/src/proxy/main.ts
@@ -192,15 +192,18 @@ const MAX_EFFECTIVE_PROMPT_BYTES = 100_000
  */
 export function foldTurnsIntoSystemPrompt(
   systemPrompt: string,
-  turns: { userText: string; assistantText: string }[],
+  turns: { userText: string; assistantText: string; isCompaction?: boolean }[],
 ): string {
   if (turns.length === 0) {
     return systemPrompt
   }
 
-  const contextParts = turns.map(
-    (t) => `User: ${t.userText}${t.assistantText ? `\nAssistant: ${t.assistantText}` : ''}`,
-  )
+  const contextParts = turns.map((t) => {
+    if (t.isCompaction) {
+      return `<context>\n${t.userText}\n</context>`
+    }
+    return `User: ${t.userText}${t.assistantText ? `\nAssistant: ${t.assistantText}` : ''}`
+  })
 
   // Try full fold first
   const fullFold = `${systemPrompt}\n\nPrevious conversation context:\n${contextParts.join('\n\n')}`
@@ -208,29 +211,55 @@ export function foldTurnsIntoSystemPrompt(
     return fullFold
   }
 
-  // Truncate oldest turns until under the cap
+  // Truncate oldest turns until under the cap.
+  // Compaction/context-summary turns are prioritized — they are reserved first
+  // so that pre-compaction context survives truncation.  Real conversation turns
+  // fill the remaining budget newest-first.
   console.error(
     `[proxy] Folded system prompt exceeds ${String(MAX_EFFECTIVE_PROMPT_BYTES)} bytes — truncating oldest turns`,
   )
-  const kept: string[] = []
   const prefix = `${systemPrompt}\n\nPrevious conversation context (oldest turns truncated):\n`
   let budget = MAX_EFFECTIVE_PROMPT_BYTES - new TextEncoder().encode(prefix).byteLength
 
-  // Walk from newest to oldest, keeping what fits
-  for (let i = contextParts.length - 1; i >= 0; i--) {
-    const partBytes = new TextEncoder().encode(contextParts[i]).byteLength + 2 // +2 for '\n\n' separator
+  // Partition into compaction and regular indices
+  const compactionIndices: number[] = []
+  const regularIndices: number[] = []
+  for (let i = 0; i < turns.length; i++) {
+    if (turns[i].isCompaction) {
+      compactionIndices.push(i)
+    } else {
+      regularIndices.push(i)
+    }
+  }
+
+  // Reserve budget for compaction turns first (in original order)
+  const keptIndices = new Set<number>()
+  for (const idx of compactionIndices) {
+    const partBytes = new TextEncoder().encode(contextParts[idx]).byteLength + 2
     if (partBytes > budget) {
       break
     }
     budget -= partBytes
-    kept.unshift(contextParts[i])
+    keptIndices.add(idx)
   }
 
-  if (kept.length === 0) {
-    // Even one turn doesn't fit — just return the system prompt
+  // Fill remaining budget with regular turns, newest first
+  for (let i = regularIndices.length - 1; i >= 0; i--) {
+    const idx = regularIndices[i]
+    const partBytes = new TextEncoder().encode(contextParts[idx]).byteLength + 2
+    if (partBytes > budget) {
+      break
+    }
+    budget -= partBytes
+    keptIndices.add(idx)
+  }
+
+  if (keptIndices.size === 0) {
     return systemPrompt
   }
 
+  // Reassemble in original order
+  const kept = [...keptIndices].sort((a, b) => a - b).map((i) => contextParts[i])
   return `${prefix}${kept.join('\n\n')}`
 }
 
@@ -238,7 +267,7 @@ function buildCursorRequest(
   modelId: string,
   systemPrompt: string,
   userText: string,
-  turns: { userText: string; assistantText: string }[],
+  turns: { userText: string; assistantText: string; isCompaction?: boolean }[],
   conversationId: string,
   checkpoint: Uint8Array | null,
   blobStore: Map<string, Uint8Array>,

--- a/packages/pi-cursor/src/proxy/openai-messages.test.ts
+++ b/packages/pi-cursor/src/proxy/openai-messages.test.ts
@@ -1,7 +1,14 @@
 // src/proxy/openai-messages.test.ts
 import { describe, it, expect } from 'vitest'
 
-import { extractImageParts, parseMessages, selectToolsForChoice, textContent } from './openai-messages.ts'
+import {
+  COMPACTION_MARKERS,
+  extractImageParts,
+  isCompactionText,
+  parseMessages,
+  selectToolsForChoice,
+  textContent,
+} from './openai-messages.ts'
 import type { OpenAIMessage, OpenAIToolDef } from './openai-messages.ts'
 
 describe('textContent', () => {
@@ -253,5 +260,119 @@ describe('selectToolsForChoice', () => {
   it('returns empty when specific function not found', () => {
     const result = selectToolsForChoice(tools, { type: 'function', function: { name: 'nonexistent' } })
     expect(result).toHaveLength(0)
+  })
+})
+
+describe('COMPACTION_MARKERS sync check', () => {
+  // These are the full prefixes from @mariozechner/pi-coding-agent dist/core/messages.js.
+  // If pi-core changes them, update COMPACTION_MARKERS and these expected values.
+  const PI_CORE_COMPACTION_PREFIX =
+    'The conversation history before this point was compacted into the following summary:\n\n<summary>\n'
+  const PI_CORE_BRANCH_PREFIX =
+    'The following is a summary of a branch that this conversation came back from:\n\n<summary>\n'
+
+  it('compaction marker matches the start of pi-core COMPACTION_SUMMARY_PREFIX', () => {
+    expect(PI_CORE_COMPACTION_PREFIX.startsWith(COMPACTION_MARKERS[0])).toBeTruthy()
+  })
+
+  it('branch marker matches the start of pi-core BRANCH_SUMMARY_PREFIX', () => {
+    expect(PI_CORE_BRANCH_PREFIX.startsWith(COMPACTION_MARKERS[1])).toBeTruthy()
+  })
+})
+
+describe('isCompactionText', () => {
+  it('detects compaction summary prefix', () => {
+    const text =
+      'The conversation history before this point was compacted into the following summary:\n\n<summary>\nThe user discussed rules.\n</summary>'
+    expect(isCompactionText(text)).toBeTruthy()
+  })
+
+  it('detects branch summary prefix', () => {
+    const text =
+      'The following is a summary of a branch that this conversation came back from:\n\n<summary>\nBranch context.\n</summary>'
+    expect(isCompactionText(text)).toBeTruthy()
+  })
+
+  it('returns false for regular user text', () => {
+    expect(isCompactionText('Hello, how are you?')).toBeFalsy()
+  })
+
+  it('returns false for empty string', () => {
+    expect(isCompactionText('')).toBeFalsy()
+  })
+
+  it('returns false for text that mentions compaction but does not start with the prefix', () => {
+    expect(isCompactionText('I see the conversation history was compacted')).toBeFalsy()
+  })
+})
+
+describe('parseMessages — compaction detection', () => {
+  const compactionText =
+    'The conversation history before this point was compacted into the following summary:\n\n<summary>\nThe user asked about rules.\n</summary>'
+
+  it('tags compaction turns with isCompaction: true', () => {
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: compactionText },
+      { role: 'assistant', content: 'Understood.' },
+      { role: 'user', content: 'Hello' },
+    ]
+    const result = parseMessages(messages)
+    expect(result.turns).toHaveLength(1)
+    expect(result.turns[0].isCompaction).toBeTruthy()
+    expect(result.turns[0].userText).toBe(compactionText)
+    expect(result.userText).toBe('Hello')
+  })
+
+  it('tags regular turns with isCompaction: false', () => {
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'How are you?' },
+    ]
+    const result = parseMessages(messages)
+    expect(result.turns).toHaveLength(1)
+    expect(result.turns[0].isCompaction).toBeFalsy()
+  })
+
+  it('handles mixed compaction and regular turns', () => {
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: compactionText },
+      { role: 'assistant', content: 'Understood.' },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi!' },
+      { role: 'user', content: 'What now?' },
+    ]
+    const result = parseMessages(messages)
+    expect(result.turns).toHaveLength(2)
+    expect(result.turns[0].isCompaction).toBeTruthy()
+    expect(result.turns[1].isCompaction).toBeFalsy()
+    expect(result.userText).toBe('What now?')
+  })
+
+  it('detects compaction in ContentPart[] format (pi-core real format)', () => {
+    const messages: OpenAIMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: compactionText }],
+      },
+      { role: 'assistant', content: 'Understood.' },
+      { role: 'user', content: 'Hello' },
+    ]
+    const result = parseMessages(messages)
+    expect(result.turns).toHaveLength(1)
+    expect(result.turns[0].isCompaction).toBeTruthy()
+  })
+
+  it('detects branch summary turns', () => {
+    const branchText =
+      'The following is a summary of a branch that this conversation came back from:\n\n<summary>\nBranch context.\n</summary>'
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: branchText },
+      { role: 'assistant', content: 'Got it.' },
+      { role: 'user', content: 'Continue' },
+    ]
+    const result = parseMessages(messages)
+    expect(result.turns).toHaveLength(1)
+    expect(result.turns[0].isCompaction).toBeTruthy()
   })
 })

--- a/packages/pi-cursor/src/proxy/openai-messages.ts
+++ b/packages/pi-cursor/src/proxy/openai-messages.ts
@@ -40,6 +40,8 @@ export interface ParsedConversationTurn {
   userText: string
   assistantText: string
   images: ImagePart[]
+  /** True when this turn's user message is a compaction or branch summary, not a real user message. */
+  isCompaction: boolean
 }
 
 export interface ParsedMessages {
@@ -48,6 +50,24 @@ export interface ParsedMessages {
   userText: string
   images: ImagePart[]
   toolResults: ToolResultInfo[]
+}
+
+/**
+ * Prefix strings used by pi-core to wrap compaction and branch summaries.
+ * These are used to detect non-user turns in `parseMessages`.
+ *
+ * Source: `@mariozechner/pi-coding-agent` — COMPACTION_SUMMARY_PREFIX and
+ * BRANCH_SUMMARY_PREFIX from `dist/core/messages.js`.  Not imported directly
+ * to avoid a heavy/circular dependency; kept in sync manually.
+ */
+export const COMPACTION_MARKERS = [
+  'The conversation history before this point was compacted into the following summary:',
+  'The following is a summary of a branch that this conversation came back from:',
+] as const
+
+/** Returns true if the text starts with a known compaction/branch summary prefix. */
+export function isCompactionText(text: string): boolean {
+  return COMPACTION_MARKERS.some((marker) => text.startsWith(marker))
 }
 
 /**
@@ -167,6 +187,7 @@ export function parseMessages(messages: OpenAIMessage[]): ParsedMessages {
         userText: user.text,
         assistantText: assistant.text,
         images: user.images,
+        isCompaction: isCompactionText(user.text),
       })
       userIdx++
       assistantIdx++

--- a/packages/pi-cursor/src/proxy/request-builder.test.ts
+++ b/packages/pi-cursor/src/proxy/request-builder.test.ts
@@ -81,4 +81,53 @@ describe('foldTurnsIntoSystemPrompt', () => {
     const result = foldTurnsIntoSystemPrompt('System prompt', [{ userText: hugeText, assistantText: 'response' }])
     expect(result).toBe('System prompt')
   })
+
+  it('wraps compaction turns in <context> tags instead of User prefix', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [
+      { userText: 'compacted context here', assistantText: 'Understood.', isCompaction: true },
+      { userText: 'Hello', assistantText: 'Hi!', isCompaction: false },
+    ])
+    expect(result).toContain('<context>\ncompacted context here\n</context>')
+    expect(result).not.toMatch(/User: compacted context here/)
+    // Assistant acknowledgment is dropped for compaction turns
+    expect(result).not.toContain('Assistant: Understood.')
+    expect(result).toContain('User: Hello')
+    expect(result).toContain('Assistant: Hi!')
+  })
+
+  it('handles all-compaction turns', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [
+      { userText: 'summary A', assistantText: 'ok', isCompaction: true },
+      { userText: 'summary B', assistantText: 'ok', isCompaction: true },
+    ])
+    expect(result).toContain('<context>\nsummary A\n</context>')
+    expect(result).toContain('<context>\nsummary B\n</context>')
+    expect(result).not.toContain('User:')
+    expect(result).not.toContain('Assistant:')
+  })
+
+  it('treats undefined isCompaction as regular user turn', () => {
+    const result = foldTurnsIntoSystemPrompt('System', [{ userText: 'Hello', assistantText: 'Hi!' }])
+    expect(result).toContain('User: Hello')
+    expect(result).not.toContain('<context>')
+  })
+
+  it('prioritizes compaction turns over regular turns during truncation', () => {
+    // Each turn ~45KB, total ~135KB exceeds 100KB cap.
+    // Without prioritization, newest-first would keep newest + middle, dropping the compaction.
+    // With prioritization, compaction is reserved first, then newest regular fills the rest.
+    const bigText = 'x'.repeat(50_000)
+    const turns = [
+      { userText: `compaction-summary-${bigText}`, assistantText: 'ok', isCompaction: true },
+      { userText: `oldest-regular-${bigText}`, assistantText: 'A1', isCompaction: false },
+      { userText: 'newest-regular', assistantText: 'A2', isCompaction: false },
+    ]
+    const result = foldTurnsIntoSystemPrompt('System', turns)
+    // Compaction turn should be kept (prioritized)
+    expect(result).toContain('<context>\ncompaction-summary-')
+    // Newest regular turn should be kept (fits in remaining budget)
+    expect(result).toContain('User: newest-regular')
+    // Oldest regular turn should be dropped (budget exceeded)
+    expect(result).not.toContain('oldest-regular')
+  })
 })


### PR DESCRIPTION
## Problem

After compaction resets the conversation checkpoint, `foldTurnsIntoSystemPrompt` folded compaction summaries using `User:` prefixes — identical to real user messages. This caused models to:

1. **Report compaction summaries as real chat history** when asked "What's our chat history?"
2. **Swap message ordering** — confusing compaction summary content with actual user input
3. **Lose all pre-compaction context during truncation** — compaction turns (always oldest) were dropped first

## Solution

Detect compaction/branch summary turns in `parseMessages()` and wrap them in `<context>` XML tags instead of `User:` prefixes when folding into the system prompt.

### Changes

- **`openai-messages.ts`** — Added `isCompaction` field to `ParsedConversationTurn`, `COMPACTION_MARKERS` constant (synced from pi-core's known prefixes), `isCompactionText()` detector, wired into `parseMessages()`
- **`main.ts`** — `foldTurnsIntoSystemPrompt()` wraps compaction turns in `<context>...</context>` tags (drops assistant acknowledgments). Updated `buildCursorRequest` type to explicitly include `isCompaction?`. Truncation now prioritizes compaction turns (reserved first, regular turns fill remaining budget newest-first)
- **Tests** — Marker sync tests, `isCompactionText()` unit tests, `parseMessages` compaction detection (tagged, untagged, mixed, `ContentPart[]` format, branch summaries), folding format tests, truncation prioritization test

### Before
```
Previous conversation context:
User: The conversation history before this point was compacted...
Assistant: Understood.

User: Hello
Assistant: Hi!
```

### After
```
Previous conversation context:
<context>
The conversation history before this point was compacted...
</context>

User: Hello
Assistant: Hi!
```

## Follow-ups (not in this PR)

- Pi-core could add explicit `name: "compaction"` metadata on OpenAI messages to eliminate string-matching
- Validate `<context>` tag effectiveness with real models