### PR TITLE
fix: expose xhigh thinking level in pi's selector

### DIFF
--- a/.changeset/xhigh-thinking-level.md
+++ b/.changeset/xhigh-thinking-level.md
@@ -1,0 +1,13 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Expose xhigh thinking level in pi's thinking-level selector
+
+Pi-core's `getSupportedThinkingLevels` only includes `xhigh` when the model's
+`thinkingLevelMap` explicitly defines it (unlike other levels which are opt-out).
+Pi-cursor was not setting `thinkingLevelMap` at all, so `xhigh` never appeared
+in the selector.
+
+Now sets `thinkingLevelMap: { xhigh: 'xhigh' }` for models with effort maps,
+which passes through to the proxy's `buildEffortMap` for Cursor effort resolution.

--- a/packages/pi-cursor/src/index.ts
+++ b/packages/pi-cursor/src/index.ts
@@ -57,7 +57,11 @@ function toProviderModels(models: CursorModel[], modelSet?: NormalizedModelSet):
       maxTokens: m.maxTokens,
     }
 
-    // When normalized, set reasoning effort compat for models with effort maps
+    // When normalized, set reasoning effort compat and thinkingLevelMap for
+    // models with effort maps.  Pi-core requires thinkingLevelMap.xhigh to be
+    // explicitly defined for xhigh to appear in the thinking-level selector.
+    // The map values pass through as-is to the proxy, which maps them via
+    // buildEffortMap to the actual Cursor effort suffixes.
     if (modelSet) {
       const parsed = parseModelId(m.id)
       const fKey = familyKey(parsed.base, parsed.thinking, parsed.fast)
@@ -68,6 +72,19 @@ function toProviderModels(models: CursorModel[], modelSet?: NormalizedModelSet):
           supportsReasoningEffort: true,
           reasoningEffortMap: effortMap,
         } as ProviderModelConfig['compat']
+
+        // Explicitly define all effort levels in thinkingLevelMap so pi-core's
+        // getSupportedThinkingLevels includes them.  Currently only xhigh is
+        // opt-in (requires explicit definition), but defining all levels
+        // future-proofs against new opt-in levels.  The values pass through
+        // as reasoning_effort to the proxy, which maps them via effortMap.
+        // 'off' is excluded — it's always available and sending it as
+        // reasoning_effort would be a no-op the proxy doesn't expect.
+        const thinkingLevelMap: Record<string, string> = {}
+        for (const key of Object.keys(effortMap)) {
+          thinkingLevelMap[key] = key
+        }
+        base.thinkingLevelMap = thinkingLevelMap
       }
     }
 


### PR DESCRIPTION
## Problem

`xhigh` never appeared in pi's thinking-level selector (ctrl+t) for Cursor models.

## Root Cause

Pi-core's `getSupportedThinkingLevels` (in `@mariozechner/pi-ai/dist/models.js`) treats `xhigh` as **opt-in**: it only includes it when `model.thinkingLevelMap.xhigh` is explicitly defined. All other levels (off, minimal, low, medium, high) are **opt-out** (included by default unless set to `null`).

Pi-cursor was not setting `thinkingLevelMap` at all when registering models via `toProviderModels`, so `xhigh` was always filtered out.

## Fix

Set `thinkingLevelMap: { xhigh: 'xhigh' }` for models that have effort maps. The value `'xhigh'` passes through as the `reasoning_effort` parameter to the proxy, where `buildEffortMap` maps it to the best available Cursor effort suffix (prefers `max`, then `xhigh`, then `high`).

## Changes

- **`packages/pi-cursor/src/index.ts`** — `toProviderModels` now sets `base.thinkingLevelMap = { xhigh: 'xhigh' }` for models with effort maps