### PR TITLE
fix(pi-cursor): preserve proxy clients across sleep/resume heartbeat gaps

### DIFF
--- a/.changeset/fix-cursor-sleep-resume.md
+++ b/.changeset/fix-cursor-sleep-resume.md
@@ -1,0 +1,5 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Keep active proxy clients alive when the heartbeat monitor resumes after system sleep.

--- a/packages/pi-cursor/README.md
+++ b/packages/pi-cursor/README.md
@@ -190,7 +190,7 @@ The `agent_pb.ts` is vendored directly (the `.proto` source is not publicly avai
 4. **Provider registration** — Extension registers a `cursor` provider with Pi using `api: 'openai-completions'`, pointing `baseUrl` at the local proxy.
 5. **Chat completion** — Pi sends standard OpenAI requests to the proxy. The proxy builds an `AgentRunRequest` protobuf, opens an H2 stream to `api2.cursor.sh`, and translates the response back into SSE chunks.
 6. **Tool calls** — Cursor's native tools (read, write, shell) are intercepted and emitted as OpenAI `tool_calls` only if the mapped Pi tool is enabled for the session. MCP tool calls are gated against the same registered tool set, and Cursor-only web/exa queries are rejected so the model falls back to available tools. Results flow back as protobuf frames.
-7. **Multi-session** — The proxy writes a port file at `~/.pi/agent/cursor-proxy.json`. Other Pi sessions discover and reuse the same proxy. Each session sends heartbeats every 10s; the proxy exits 30s after the last heartbeat stops.
+7. **Multi-session** — The proxy writes a port file at `~/.pi/agent/cursor-proxy.json`. Other Pi sessions discover and reuse the same proxy. Each session sends heartbeats every 10s; the proxy exits 30s after the last heartbeat stops. If the heartbeat monitor itself was suspended past that timeout (e.g. system sleep), sessions that were active before the gap get one fresh heartbeat window on resume instead of being evicted.
 
 ## License
 

--- a/packages/pi-cursor/README.md
+++ b/packages/pi-cursor/README.md
@@ -190,7 +190,7 @@ The `agent_pb.ts` is vendored directly (the `.proto` source is not publicly avai
 4. **Provider registration** — Extension registers a `cursor` provider with Pi using `api: 'openai-completions'`, pointing `baseUrl` at the local proxy.
 5. **Chat completion** — Pi sends standard OpenAI requests to the proxy. The proxy builds an `AgentRunRequest` protobuf, opens an H2 stream to `api2.cursor.sh`, and translates the response back into SSE chunks.
 6. **Tool calls** — Cursor's native tools (read, write, shell) are intercepted and emitted as OpenAI `tool_calls` only if the mapped Pi tool is enabled for the session. MCP tool calls are gated against the same registered tool set, and Cursor-only web/exa queries are rejected so the model falls back to available tools. Results flow back as protobuf frames.
-7. **Multi-session** — The proxy writes a port file at `~/.pi/agent/cursor-proxy.json`. Other Pi sessions discover and reuse the same proxy. Each session sends heartbeats every 10s; the proxy exits 30s after the last heartbeat stops. If the heartbeat monitor itself was suspended past that timeout (e.g. system sleep), sessions that were active before the gap get one fresh heartbeat window on resume instead of being evicted.
+7. **Multi-session** — The proxy writes a port file at `~/.pi/agent/cursor-proxy.json`. Other Pi sessions discover and reuse the same proxy. Each session sends heartbeats every 10s; the proxy exits 30s after the last heartbeat stops. If the heartbeat monitor misses its expected cadence (e.g. system sleep), sessions that were active before the gap get one fresh heartbeat window on resume instead of being evicted.
 
 ## License
 

--- a/packages/pi-cursor/src/proxy-lifecycle.ts
+++ b/packages/pi-cursor/src/proxy-lifecycle.ts
@@ -6,7 +6,8 @@
  *
  * Multiple Pi sessions share one proxy via the port file at
  * ~/.pi/agent/cursor-proxy.json. Each session sends heartbeats;
- * the proxy self-exits after 30s without any heartbeat.
+ * the proxy self-exits once heartbeats stop (timeout and sleep-resume
+ * grace rules live in proxy/internal-api.ts).
  */
 import { spawn } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'

--- a/packages/pi-cursor/src/proxy/internal-api.test.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { configureInternalApi, handleInternalRequest, startHeartbeatMonitor } from './internal-api.ts'
 
 const START_MS = Date.UTC(2026, 7, 13)
+const HEARTBEAT_MONITOR_INTERVAL_MS = 10_000
 
 interface InternalApi {
   configureInternalApi: typeof configureInternalApi
@@ -42,6 +43,11 @@ async function getSessionCount(): Promise<number> {
   return (JSON.parse(responseBody) as { sessions: number }).sessions
 }
 
+async function advanceMonitorAfterGap(gapMs: number): Promise<void> {
+  vi.setSystemTime(Date.now() + gapMs - HEARTBEAT_MONITOR_INTERVAL_MS)
+  await vi.advanceTimersToNextTimerAsync()
+}
+
 beforeEach(async () => {
   vi.useFakeTimers({ now: START_MS })
   vi.resetModules()
@@ -56,17 +62,36 @@ afterEach(() => {
 describe('startHeartbeatMonitor', () => {
   it('preserves clients when the monitor resumes after a long suspension', async () => {
     const onShutdown = vi.fn<() => void>()
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
     await sendHeartbeat('session-a')
     await sendHeartbeat('session-b')
     internalApi.startHeartbeatMonitor()
 
-    vi.setSystemTime(START_MS + 40_000)
-    await vi.advanceTimersToNextTimerAsync()
+    await advanceMonitorAfterGap(40_000)
 
     expect(onShutdown).not.toHaveBeenCalled()
     expect(await getSessionCount()).toBe(2)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[proxy] Heartbeat monitor resumed after 40000ms; granting active sessions a fresh heartbeat window',
+    )
+  })
+
+  it('preserves a stale client after a shorter monitor suspension', async () => {
+    const onShutdown = vi.fn<() => void>()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
+    await sendHeartbeat('session-a')
+    internalApi.startHeartbeatMonitor()
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MONITOR_INTERVAL_MS)
+
+    await advanceMonitorAfterGap(22_000)
+
+    expect(onShutdown).not.toHaveBeenCalled()
+    expect(await getSessionCount()).toBe(1)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[proxy] Heartbeat monitor resumed after 22000ms; granting active sessions a fresh heartbeat window',
+    )
   })
 
   it('shuts down after a long monitor gap when no clients are registered', async () => {
@@ -75,8 +100,7 @@ describe('startHeartbeatMonitor', () => {
     internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
     internalApi.startHeartbeatMonitor()
 
-    vi.setSystemTime(START_MS + 40_000)
-    await vi.advanceTimersToNextTimerAsync()
+    await advanceMonitorAfterGap(40_000)
 
     expect(onShutdown).toHaveBeenCalledOnce()
   })
@@ -100,11 +124,13 @@ describe('startHeartbeatMonitor', () => {
     await sendHeartbeat('session-a')
     internalApi.startHeartbeatMonitor()
 
-    vi.setSystemTime(START_MS + 40_000)
-    await vi.advanceTimersToNextTimerAsync()
+    await advanceMonitorAfterGap(40_000)
     expect(onShutdown).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(40_000)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(onShutdown).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10_000)
 
     expect(onShutdown).toHaveBeenCalledOnce()
   })

--- a/packages/pi-cursor/src/proxy/internal-api.test.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.test.ts
@@ -1,0 +1,111 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { configureInternalApi, handleInternalRequest, startHeartbeatMonitor } from './internal-api.ts'
+
+const START_MS = Date.UTC(2026, 7, 13)
+
+interface InternalApi {
+  configureInternalApi: typeof configureInternalApi
+  handleInternalRequest: typeof handleInternalRequest
+  startHeartbeatMonitor: typeof startHeartbeatMonitor
+}
+
+let internalApi: InternalApi
+
+async function sendHeartbeat(sessionId: string): Promise<void> {
+  const stream = new PassThrough()
+  const req = Object.assign(stream, { method: 'POST' }) as unknown as IncomingMessage
+  const res = {
+    writeHead: vi.fn<() => void>(),
+    end: vi.fn<() => void>(),
+  } as unknown as ServerResponse
+
+  const response = internalApi.handleInternalRequest(req, res, '/internal/heartbeat')
+  stream.end(JSON.stringify({ sessionId }))
+  await response
+}
+
+async function getSessionCount(): Promise<number> {
+  const req = Object.assign(new PassThrough(), { method: 'GET' }) as unknown as IncomingMessage
+  let responseBody = ''
+  const res = {
+    writeHead: vi.fn<() => void>(),
+    end: vi.fn<(body: string) => void>((body) => {
+      responseBody = body
+    }),
+  } as unknown as ServerResponse
+
+  await internalApi.handleInternalRequest(req, res, '/internal/health')
+  return (JSON.parse(responseBody) as { sessions: number }).sessions
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers({ now: START_MS })
+  vi.resetModules()
+  internalApi = await import('./internal-api.ts')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('startHeartbeatMonitor', () => {
+  it('preserves clients when the monitor resumes after a long suspension', async () => {
+    const onShutdown = vi.fn<() => void>()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
+    await sendHeartbeat('session-a')
+    await sendHeartbeat('session-b')
+    internalApi.startHeartbeatMonitor()
+
+    vi.setSystemTime(START_MS + 40_000)
+    await vi.advanceTimersToNextTimerAsync()
+
+    expect(onShutdown).not.toHaveBeenCalled()
+    expect(await getSessionCount()).toBe(2)
+  })
+
+  it('shuts down after a long monitor gap when no clients are registered', async () => {
+    const onShutdown = vi.fn<() => void>()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
+    internalApi.startHeartbeatMonitor()
+
+    vi.setSystemTime(START_MS + 40_000)
+    await vi.advanceTimersToNextTimerAsync()
+
+    expect(onShutdown).toHaveBeenCalledOnce()
+  })
+
+  it('evicts a client after an ordinary heartbeat timeout', async () => {
+    const onShutdown = vi.fn<() => void>()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
+    await sendHeartbeat('session-a')
+    internalApi.startHeartbeatMonitor()
+
+    await vi.advanceTimersByTimeAsync(40_000)
+
+    expect(onShutdown).toHaveBeenCalledOnce()
+  })
+
+  it('later evicts an orphan that received a resume grace window', async () => {
+    const onShutdown = vi.fn<() => void>()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    internalApi.configureInternalApi({ initialToken: null, initialModels: [], onShutdown })
+    await sendHeartbeat('session-a')
+    internalApi.startHeartbeatMonitor()
+
+    vi.setSystemTime(START_MS + 40_000)
+    await vi.advanceTimersToNextTimerAsync()
+    expect(onShutdown).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(40_000)
+
+    expect(onShutdown).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/pi-cursor/src/proxy/internal-api.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.ts
@@ -44,8 +44,20 @@ export function getCachedModels(): CursorModel[] {
 }
 
 export function startHeartbeatMonitor(): NodeJS.Timeout {
+  let previousMonitorMs = Date.now()
   const timer = setInterval(() => {
     const now = Date.now()
+    const monitorGapMs = now - previousMonitorMs
+    previousMonitorMs = now
+    if (monitorGapMs > HEARTBEAT_TIMEOUT_MS && heartbeatClients.size > 0) {
+      for (const session of heartbeatClients.values()) {
+        session.lastHeartbeatMs = now
+      }
+      console.error(
+        `[proxy] Heartbeat monitor resumed after ${String(monitorGapMs)}ms; granting active sessions a fresh heartbeat window`,
+      )
+      return
+    }
     for (const [id] of heartbeatClients) {
       const session = heartbeatClients.get(id)
       if (session && now - session.lastHeartbeatMs > HEARTBEAT_TIMEOUT_MS) {

--- a/packages/pi-cursor/src/proxy/internal-api.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.ts
@@ -53,7 +53,9 @@ export function startHeartbeatMonitor(): NodeJS.Timeout {
     previousMonitorMs = now
     if (monitorGapMs > SUSPEND_DETECTION_THRESHOLD_MS && heartbeatClients.size > 0) {
       // Rewrite timestamps, rather than only skipping this sweep, so client
-      // heartbeat timers have a full window to resume after wake.
+      // heartbeat timers have a full window to resume after wake. An
+      // already-dead client gets the same window, delaying its eviction by up
+      // to one heartbeat window; later ordinary sweeps still evict it.
       for (const session of heartbeatClients.values()) {
         session.lastHeartbeatMs = now
       }

--- a/packages/pi-cursor/src/proxy/internal-api.ts
+++ b/packages/pi-cursor/src/proxy/internal-api.ts
@@ -17,6 +17,8 @@ interface SessionHeartbeat {
 
 const heartbeatClients = new Map<string, SessionHeartbeat>()
 const HEARTBEAT_TIMEOUT_MS = 30_000
+const HEARTBEAT_MONITOR_INTERVAL_MS = 10_000
+const SUSPEND_DETECTION_THRESHOLD_MS = HEARTBEAT_MONITOR_INTERVAL_MS * 1.5
 
 let currentAccessToken: string | null = null
 let cachedModels: CursorModel[] = []
@@ -49,7 +51,9 @@ export function startHeartbeatMonitor(): NodeJS.Timeout {
     const now = Date.now()
     const monitorGapMs = now - previousMonitorMs
     previousMonitorMs = now
-    if (monitorGapMs > HEARTBEAT_TIMEOUT_MS && heartbeatClients.size > 0) {
+    if (monitorGapMs > SUSPEND_DETECTION_THRESHOLD_MS && heartbeatClients.size > 0) {
+      // Rewrite timestamps, rather than only skipping this sweep, so client
+      // heartbeat timers have a full window to resume after wake.
       for (const session of heartbeatClients.values()) {
         session.lastHeartbeatMs = now
       }
@@ -68,7 +72,7 @@ export function startHeartbeatMonitor(): NodeJS.Timeout {
       console.error('[proxy] No active sessions, shutting down')
       shutdownCallback?.()
     }
-  }, 10_000)
+  }, HEARTBEAT_MONITOR_INTERVAL_MS)
   if (typeof timer === 'object' && 'unref' in timer) {
     timer.unref()
   }


### PR DESCRIPTION
## Intent

# Accepted intent

Contribute the verified Mac sleep/resume repair for `@schultzp2020/pi-cursor` to `schultzp2020/pi-extensions`.

- Fix the TypeScript source, not only bundled output.
- Detect a heartbeat-monitor tick gap longer than `HEARTBEAT_TIMEOUT_MS`.
- If registered clients existed across that gap, grant them one fresh heartbeat window and skip that sweep.
- Preserve normal timeout eviction and proxy shutdown when the parent is genuinely gone.
- Cover suspend/resume, no-client behavior, ordinary timeout eviction, and later orphan cleanup with focused deterministic fake-timer regressions.
- Keep the patch minimal and consistent with repository conventions.
- Preserve the evidence and privacy boundaries in upstream issue https://github.com/schultzp2020/pi-extensions/issues/34; include no captain-specific paths, session text, tokens, or private data.
- Run the repository's focused and full tests, formatting, lint, type checks, and build.
- Open a PR from the `g7adrian/pi-extensions` fork to `schultzp2020/pi-extensions:main`, reference issue 34 without auto-closing it unless repository convention clearly prefers that, and do not merge.

## What Changed

- The proxy heartbeat monitor in `internal-api.ts` now tracks the time between its own ticks; when a tick gap exceeds `HEARTBEAT_TIMEOUT_MS` (e.g. after system sleep) and registered clients exist, it resets every session's `lastHeartbeatMs` and skips that sweep, granting active sessions one fresh heartbeat window instead of evicting them and shutting the proxy down. Ordinary timeout eviction and no-client shutdown behavior are unchanged.
- Added deterministic fake-timer regression tests (`internal-api.test.ts`) covering client preservation across a monitor suspension, shutdown after a gap with no registered clients, ordinary heartbeat-timeout eviction, and later cleanup of an orphan that received a resume grace window.
- Added a patch changeset for `@schultzp2020/pi-cursor` and documented the sleep-resume grace window in the package README and the `proxy-lifecycle.ts` module comment.

## Risk Assessment

✅ Low: A minimal, spec-conformant grace-window guard at the single heartbeat-sweep boundary, with deterministic fake-timer regression tests covering all four intent-required scenarios (including one that fails against the pre-fix code), correct changeset and docs, and no privacy or convention violations.

## Testing

Ran the four new deterministic fake-timer heartbeat regressions (all pass at the target commit; the two sleep-resume tests fail against the pre-fix implementation, confirming true regressions), then demonstrated the fix end-to-end by SIGSTOP/SIGCONT-ing the real built proxy process for 35s: the registered session survived the gap, the proxy logged the grace-window message, and it still self-terminated once heartbeats stopped, so normal orphan cleanup is preserved.

<details>
<summary>Evidence: Live sleep/resume demo transcript (real proxy, SIGSTOP 35s → SIGCONT)</summary>

<code>[12:33:42] Registering session &#39;demo-session&#39; via POST /internal/heartbeat&#10;[12:33:42] -&gt; {&#34;ok&#34;:true}&#10;[12:33:42] Health before sleep: {&#34;status&#34;:&#34;ok&#34;,&#34;sessions&#34;:1,&#34;hasToken&#34;:true,&#34;modelCount&#34;:0}&#10;[12:33:42] Simulating system sleep: kill -STOP 72336, sleeping 35s (heartbeat timeout is 30s)&#10;[12:34:17] Simulating wake: kill -CONT 72336&#10;[12:34:29] Proxy still ALIVE after 35s suspend gap&#10;[12:34:29] Health after resume: {&#34;status&#34;:&#34;ok&#34;,&#34;sessions&#34;:1,&#34;hasToken&#34;:true,&#34;modelCount&#34;:0}&#10;[12:34:29] Now stopping all heartbeats to verify orphan cleanup still works...&#10;[12:34:48] Proxy self-terminated after heartbeats stopped (orphan cleanup preserved)&#10;| [proxy] Heartbeat monitor resumed after 35324ms; granting active sessions a fresh heartbeat window&#10;| [proxy] No active sessions, shutting down&#10;[12:34:48] DEMO PASSED: session survived the sleep gap; orphan shutdown still works</code>

```text
[12:33:41] Starting real proxy: node dist/proxy/main.js (HOME sandboxed to scratch dir)
[12:33:41] Proxy PID: 72336
[12:33:42] Proxy ready on port 54586
[12:33:42] Registering session 'demo-session' via POST /internal/heartbeat
[12:33:42]   -> {"ok":true}
[12:33:42] Health before sleep: {"status":"ok","sessions":1,"hasToken":true,"modelCount":0}
[12:33:42] Simulating system sleep: kill -STOP 72336, sleeping 35s (heartbeat timeout is 30s)
[12:34:17] Simulating wake: kill -CONT 72336
[12:34:17] Waiting 12s for the next heartbeat-monitor tick after resume...
[12:34:29] Proxy still ALIVE after 35s suspend gap
[12:34:29] Health after resume: {"status":"ok","sessions":1,"hasToken":true,"modelCount":0}
[12:34:29] Now stopping all heartbeats to verify orphan cleanup still works...
[12:34:29] Waiting up to 60s for the proxy to self-terminate...
[12:34:48] Proxy self-terminated after heartbeats stopped (orphan cleanup preserved)
[12:34:48] Proxy stderr log:
    | [proxy] Discovered 0 models
    | [proxy] Listening on port 54586
    | [proxy] Heartbeat monitor resumed after 35324ms; granting active sessions a fresh heartbeat window
    | [proxy] No active sessions, shutting down
    | [proxy] Shutdown requested
[12:34:48] DEMO PASSED: session survived the sleep gap; orphan shutdown still works
```
</details>
<details>
<summary>Evidence: Focused vitest run at target commit (4/4 pass)</summary>

```text

 RUN  v4.1.7 /Users/adrian/.no-mistakes/worktrees/e075deef4c06/01KZYKRXRPHS114F34WH2CF9VM/packages/pi-cursor

 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > preserves clients when the monitor resumes after a long suspension 194ms
 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > shuts down after a long monitor gap when no clients are registered 15ms
 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > evicts a client after an ordinary heartbeat timeout 13ms
 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > later evicts an orphan that received a resume grace window 7ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  12:31:14
   Duration  375ms (transform 130ms, setup 0ms, import 26ms, tests 231ms, environment 0ms)
```
</details>
<details>
<summary>Evidence: Same tests against pre-fix implementation (2 sleep-resume tests fail, proving real regressions)</summary>

```text

 RUN  v4.1.7 /Users/adrian/.no-mistakes/worktrees/e075deef4c06/01KZYKRXRPHS114F34WH2CF9VM/packages/pi-cursor

 × src/proxy/internal-api.test.ts > startHeartbeatMonitor > preserves clients when the monitor resumes after a long suspension 170ms
   → expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > shuts down after a long monitor gap when no clients are registered 13ms
 ✓ src/proxy/internal-api.test.ts > startHeartbeatMonitor > evicts a client after an ordinary heartbeat timeout 11ms
 × src/proxy/internal-api.test.ts > startHeartbeatMonitor > later evicts an orphan that received a resume grace window 8ms
   → expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1


⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/proxy/internal-api.test.ts > startHeartbeatMonitor > preserves clients when the monitor resumes after a long suspension
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ❯ src/proxy/internal-api.test.ts:68:28
     66|     await vi.advanceTimersToNextTimerAsync()
     67|
     68|     expect(onShutdown).not.toHaveBeenCalled()
       |                            ^
     69|     expect(await getSessionCount()).toBe(2)
     70|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/proxy/internal-api.test.ts > startHeartbeatMonitor > later evicts an orphan that received a resume grace window
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ❯ src/proxy/internal-api.test.ts:105:28
    103|     vi.setSystemTime(START_MS + 40_000)
    104|     await vi.advanceTimersToNextTimerAsync()
    105|     expect(onShutdown).not.toHaveBeenCalled()
       |                            ^
    106|
    107|     await vi.advanceTimersByTimeAsync(40_000)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
   Start at  12:31:23
   Duration  334ms (transform 107ms, setup 0ms, import 20ms, tests 202ms, environment 0ms)
```
</details>
<details>
<summary>Evidence: Proxy stderr log from live demo (grace-window and shutdown messages)</summary>

```text
[proxy] Discovered 0 models
[proxy] Listening on port 54586
[proxy] Heartbeat monitor resumed after 35324ms; granting active sessions a fresh heartbeat window
[proxy] No active sessions, shutting down
[proxy] Shutdown requested
```
</details>
<details>
<summary>Evidence: Reproducible demo script</summary>

```text
#!/bin/zsh
# Live end-to-end demo of the pi-cursor proxy sleep/resume fix.
#
# Runs the real built proxy (dist/proxy/main.js), registers a session via the
# real /internal/heartbeat HTTP endpoint, then SIGSTOPs the proxy process for
# 35s (> HEARTBEAT_TIMEOUT_MS = 30s) to reproduce a system-sleep gap, resumes
# it with SIGCONT, and verifies the session survives. Finally it stops sending
# heartbeats and verifies the proxy still self-terminates as an orphan.
#
# HOME is redirected to a scratch dir so the proxy cannot touch the real
# ~/.pi/agent/cursor-proxy.json.
set -u
PKG_DIR="$1"
EVIDENCE_DIR="$2"
SCRATCH="$EVIDENCE_DIR/scratch-home"
mkdir -p "$SCRATCH"

ts() { print -r -- "[$(date '+%H:%M:%S')] $*" }

ts "Starting real proxy: node dist/proxy/main.js (HOME sandboxed to scratch dir)"
CONFIG='{"accessToken":"demo-invalid-token","conversationDir":"'"$SCRATCH"'/conversations"}'
( print -r -- "$CONFIG"; sleep 600 ) | \
  HOME="$SCRATCH" node "$PKG_DIR/dist/proxy/main.js" \
  > "$EVIDENCE_DIR/proxy-stdout.log" 2> "$EVIDENCE_DIR/proxy-stderr.log" &
PROXY_PID=$!
ts "Proxy PID: $PROXY_PID"

# Wait for ready signal (model discovery with the fake token fails gracefully)
PORT=""
for i in {1..60}; do
  if grep -q '"type":"ready"' "$EVIDENCE_DIR/proxy-stdout.log" 2>/dev/null; then
    PORT=$(sed -n 's/.*"port":\([0-9]*\).*/\1/p' "$EVIDENCE_DIR/proxy-stdout.log" | head -1)
    break
  fi
  sleep 1
done
if [[ -z "$PORT" ]]; then
  ts "FAIL: proxy never became ready"; kill "$PROXY_PID" 2>/dev/null; exit 1
fi
ts "Proxy ready on port $PORT"

ts "Registering session 'demo-session' via POST /internal/heartbeat"
ts "  -> $(curl -s -X POST -d '{"sessionId":"demo-session"}' "http://127.0.0.1:$PORT/internal/heartbeat")"
ts "Health before sleep: $(curl -s "http://127.0.0.1:$PORT/internal/health")"

ts "Simulating system sleep: kill -STOP $PROXY_PID, sleeping 35s (heartbeat timeout is 30s)"
kill -STOP "$PROXY_PID"
sleep 35
ts "Simulating wake: kill -CONT $PROXY_PID"
kill -CONT "$PROXY_PID"

ts "Waiting 12s for the next heartbeat-monitor tick after resume..."
sleep 12

if kill -0 "$PROXY_PID" 2>/dev/null; then
  ts "Proxy still ALIVE after 35s suspend gap"
else
  ts "FAIL: proxy died after the suspend gap (pre-fix behavior)"; exit 1
fi
ts "Health after resume: $(curl -s "http://127.0.0.1:$PORT/internal/health")"

ts "Now stopping all heartbeats to verify orphan cleanup still works..."
ts "Waiting up to 60s for the proxy to self-terminate..."
DEAD=""
for i in {1..60}; do
  if ! kill -0 "$PROXY_PID" 2>/dev/null; then DEAD=1; break; fi
  sleep 1
done
if [[ -n "$DEAD" ]]; then
  ts "Proxy self-terminated after heartbeats stopped (orphan cleanup preserved)"
else
  ts "FAIL: proxy did not self-terminate as an orphan"; kill "$PROXY_PID" 2>/dev/null; exit 1
fi

ts "Proxy stderr log:"
sed 's/^/    | /' "$EVIDENCE_DIR/proxy-stderr.log"
ts "DEMO PASSED: session survived the sleep gap; orphan shutdown still works"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/pi-cursor/src/proxy/internal-api.ts:52` - Residual gray zone inherent to the intent-specified threshold: for suspensions of roughly 20-30s, the monitor&#39;s measured tick gap can stay at or under HEARTBEAT_TIMEOUT_MS (no grace granted) while a session&#39;s heartbeat staleness exceeds it, so an unluckily phased short sleep can still evict live sessions and shut the proxy down before the client&#39;s resume heartbeat arrives. This matches the authorized detection rule (&#39;tick gap longer than HEARTBEAT_TIMEOUT_MS&#39;), is probabilistic rather than deterministic, and is far narrower than the original failure; noting the tradeoff only, no change required.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`corepack pnpm exec vitest run --reporter=verbose src/proxy/internal-api.test.ts` at target commit — all 4 heartbeat-monitor regressions pass (suspend/resume survival, no-client gap shutdown, ordinary timeout eviction, later orphan cleanup)</code>
- <code>Same vitest run with `packages/pi-cursor/src/proxy/internal-api.ts` temporarily reverted to base commit 8a0b5e15 — the two sleep-resume tests fail (proxy shut down after the simulated gap) while the two behavior-preservation tests still pass; file restored afterward</code>
- <code>Manual end-to-end demo: built the package (`corepack pnpm build`), ran the real `dist/proxy/main.js` with HOME sandboxed, registered a session via `POST /internal/heartbeat`, sent `kill -STOP` for 35s then `kill -CONT`, verified via `GET /internal/health` that the session survived and the proxy logged the resume grace-window message, then stopped heartbeats and verified the proxy self-terminated as an orphan</code>
- `Privacy check of the full diff — no captain-specific paths, session text, or tokens; tests use generic session IDs and the demo used a fake access token`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
