### PR TITLE
fix(pi-cursor): normalize model reasoning variants

### DIFF
--- a/.changeset/model-slug-effort-fidelity.md
+++ b/.changeset/model-slug-effort-fidelity.md
@@ -1,0 +1,5 @@
+---
+'@schultzp2020/pi-cursor': patch
+---
+
+Keep requested reasoning effort when a thinking or Fast variant has a thinner effort set, and pass complete model metadata through proxy startup so Pi can keep levels such as xhigh selectable.

--- a/packages/pi-cursor/CONTEXT.md
+++ b/packages/pi-cursor/CONTEXT.md
@@ -45,15 +45,15 @@ A static model list (`fallback-models.ts`) bundled with the extension containing
 _Avoid_: default models, hardcoded models
 
 **Model Normalization**:
-The process of collapsing raw Cursor model variants into deduplicated Pi-visible models. Raw IDs encode up to four dimensions: effort level, speed (`-fast`), thinking (`-thinking`), and maxMode (trailing `-max`). Parsing strips suffixes in order: trailing `-max` first, then `-fast`, then `-thinking`, then effort from the last remaining segment. Controlled by the `modelMappings` setting.
+The process of collapsing raw Cursor model variants into deduplicated Pi-visible models. Raw IDs encode effort level, speed (`-fast`), thinking (`-thinking`), and maxMode (trailing `-max` applied at request time). Parsing pops trailing `-fast`, `-thinking`, and effort suffixes (`minimal`, `none`, `low`, `medium`, `high`, `extra-high`, `xhigh`, `max`) in any order. Controlled by the `modelMappings` setting.
 _Avoid_: model dedup, model collapse
 
 **Effort Map**:
-A per-model mapping from Pi's reasoning-effort levels (`minimal`, `low`, `medium`, `high`, `xhigh`) to the best available Cursor effort suffix for that family. Built dynamically from the family's actual effort set using `buildEffortMap`. `xhigh` and `max` can coexist in the same family; when both exist, `max` is treated as the higher Cursor effort and maps to Pi's `xhigh`. Registered via the provider's model-level `thinkingLevelMap` with `compat.supportsReasoningEffort` enabled when a model supports reasoning control.
+A per-model mapping from Pi's reasoning-effort levels (`minimal`, `low`, `medium`, `high`, `xhigh`) to the best available Cursor effort suffix for that family. Built dynamically from the family's actual effort set using `buildEffortMap` so Pi's selector can keep levels such as `xhigh` selectable. `minimal` maps to `minimal` then `none` then `low`. `xhigh` maps to `max` then `xhigh` then `extra-high` then `high`. `xhigh` and `max` can coexist in the same family; when both exist, `max` is treated as the higher Cursor effort and maps to Pi's `xhigh`. Registered via the provider's model-level `thinkingLevelMap` with `compat.supportsReasoningEffort` enabled when a model supports reasoning control.
 _Avoid_: effort table, reasoning map
 
 **Effort Resolution**:
-The process of reconstructing the final Cursor model ID at request time by inserting the mapped effort suffix before any `-fast` or `-thinking` variant suffix. Performed by the Proxy using the Effort Map and global settings.
+The process of reconstructing the final Cursor model ID at request time from the variant's available efforts and global Fast/Thinking settings. Performed by the Proxy using per-variant effort sets. If the selected thinking/fast variant has no preferred match for a named Pi effort, resolve tries the next flag candidate instead of remapping that effort.
 _Avoid_: model resolution, effort insertion
 
 **Max Mode**:

--- a/packages/pi-cursor/docs/adr/0006-model-normalization-and-effort-mapping.md
+++ b/packages/pi-cursor/docs/adr/0006-model-normalization-and-effort-mapping.md
@@ -4,36 +4,31 @@ Raw Cursor model IDs encode effort level, speed variant, and thinking mode as su
 
 ## How it works
 
-Each raw Cursor model ID is parsed in order:
-
-1. Strip trailing `-max` → this is the **maxMode flag** (Cursor's max capability toggle), not an effort level
-2. Strip `-fast` → speed variant
-3. Strip `-thinking` → thinking variant
-4. Parse the last remaining segment for effort (`none`, `low`, `medium`, `high`, `xhigh`, `max`)
-
-This produces: `{base}[-{effort}][-thinking][-fast][-max(mode)]`
+Each legacy slug is parsed by popping trailing `-fast`, `-thinking`, and effort segments (`minimal`, `none`, `low`, `medium`, `high`, `extra-high`, `xhigh`, `max`) in any order. Max Mode stays a separate request-time suffix from the global setting; it is not stripped during slug parse.
 
 Critical: `-max` has **three** meanings in Cursor model IDs:
 
-- **Trailing `-max`** → maxMode flag (stripped first, controlled by global Max Mode setting)
+- **Trailing `-max` on the wire** → maxMode flag (appended at request time when Max Mode is on)
 - **Effort suffix `max`** → an effort level (e.g. `claude-4.6-opus-max` = effort `max` on base `claude-4.6-opus`)
 - **Base name component** → part of model identity (e.g. `gpt-5.1-codex-max` = a distinct model family)
 
-Models like `claude-4.6-opus-max-thinking-fast-max` have both effort `max` AND maxMode flag.
+Cursor lists preferred slugs before compatibility aliases. First-wins keeps that preferred slug.
 
-Models sharing the same `(base, variant)` with multiple effort levels or a single non-empty effort suffix are collapsed into one entry with `compat.supportsReasoningEffort: true` and a model-level `thinkingLevelMap` built from the family's effort map.
+Models sharing the same `(base, variant)` with multiple effort levels or a single non-empty effort suffix are collapsed into one entry with `compat.supportsReasoningEffort: true`. The selector `thinkingLevelMap` is the **family-union** effort map so Pi keeps levels such as `xhigh` selectable. Request-time resolve uses **per-variant** effort sets.
 
-Pi's effort levels map to Cursor suffixes via `buildEffortMap`, which picks the best available match from the family's actual effort set:
+Pi's effort levels map to Cursor suffixes via `buildEffortMap`:
 
-- `minimal` → `none` if available, else `low`, else lowest available
-- `low` → `low`
+- `minimal` → `minimal` if available, then `none`, then `low`
+- `low` → `low` if available, then `none`, then `minimal`
 - `medium` → `medium` or no suffix (default)
-- `high` → `high`
-- `xhigh` → `max` if available, else `xhigh`, else `high`
+- `high` → `high` if available, else the highest lower effort
+- `xhigh` → `max` if available, then `xhigh`, then `extra-high`, then `high`
 
 `xhigh` and `max` effort suffixes **can coexist** in the same family (e.g. `gpt-5.2` has `{low, high, xhigh, max}`). When both exist, `max` is the higher effort and maps to Pi's `xhigh`.
 
-At request time the proxy reconstructs the full Cursor model ID: `base` + effort suffix + variant suffixes (`-thinking`/`-fast`) + maxMode suffix (`-max` if global Max Mode is on and the family supports it).
+If the selected thinking/fast variant has no preferred match for a named Pi effort, resolve tries the next flag candidate instead of remapping that effort (so `low`+thinking on a sparse thinking family stays `low`; an effort-less thinking slug such as Haiku still keeps thinking).
+
+At request time the proxy reconstructs the full Cursor model ID from the resolved legacy slug, then appends maxMode (`-max`) if the global Max Mode setting is on and the family supports it.
 
 ## `modelMappings` setting
 

--- a/packages/pi-cursor/docs/prd-cursor-settings-and-model-normalization.md
+++ b/packages/pi-cursor/docs/prd-cursor-settings-and-model-normalization.md
@@ -81,8 +81,9 @@ After this change:
 
 ### Model normalization
 
-- Parser strips suffixes in order: trailing `-max` (maxMode flag), `-fast`, `-thinking`, then effort from last segment
-- Three meanings of `max`: trailing maxMode flag, effort level, base name component — all independent and composable
+- Parser pops trailing `-fast`, `-thinking`, and effort suffixes (`minimal`, `none`, `low`, `medium`, `high`, `extra-high`, `xhigh`, `max`) in any order
+- Three meanings of `max`: request-time maxMode flag, effort level, base name component — all independent
+- Preferred legacy slugs are listed first; first-wins keeps Cursor's preferred alias
 - `xhigh` and `max` effort suffixes can coexist in the same family; when both exist, `max` is higher and maps to Pi's `xhigh`
 - Extension owns the visible model list and provider compat metadata
 - Proxy owns final raw Cursor model resolution at request time
@@ -92,8 +93,10 @@ After this change:
 
 ### Effort mapping
 
-- Pi levels map to Cursor suffixes via `buildEffortMap` using the family's available effort set
-- `minimal` → `none` or `low`; `low` → `low`; `medium` → `medium` or no suffix; `high` → `high`; `xhigh` → `max` or `xhigh` or `high`
+- Selector `thinkingLevelMap` uses the family-union effort set so Pi does not clamp levels such as `xhigh`
+- Request-time resolve uses per-variant effort sets via `buildEffortMap`
+- `minimal` → `minimal` or `none` or `low`; `low` → `low` or `none` or `minimal`; `medium` → `medium` or no suffix; `high` → `high`; `xhigh` → `max` or `xhigh` or `extra-high` or `high`
+- If the selected thinking/fast variant has no preferred match for a named Pi effort, resolve tries the next flag candidate instead of remapping that effort
 - Registered via provider `compat.supportsReasoningEffort` and model-level `thinkingLevelMap`
 
 ### Native tools modes

--- a/packages/pi-cursor/src/index.ts
+++ b/packages/pi-cursor/src/index.ts
@@ -162,8 +162,8 @@ function toProviderModels(models: CursorModel[], modelSet?: NormalizedModelSet):
       maxTokens: m.maxTokens,
     }
 
-    // Expose per-model thinking controls for models with effort maps.
-    // Pi core reads thinkingLevelMap to populate the reasoning-effort selector.
+    // Family-union map so Pi keeps xhigh selectable. Request-time resolve uses
+    // per-variant efforts and will not change a named effort just to keep thinking.
     if (modelSet) {
       const effortMap = modelSet.effortMaps.get(m.id)
       if (effortMap) {

--- a/packages/pi-cursor/src/proxy-lifecycle.ts
+++ b/packages/pi-cursor/src/proxy-lifecycle.ts
@@ -909,7 +909,7 @@ async function spawnProxy(
     }
   }
 
-  let ready: Partial<ProxyReadySignal>
+  let ready: ProxyReadySignal
   try {
     const outcome = await new Promise<StartupOutcome>((resolve) => {
       // Startup terminal state. The first of ready line, startup timeout,
@@ -997,10 +997,11 @@ async function spawnProxy(
       throw new Error(outcome.message, { cause: outcome.cause })
     }
     options.signal?.throwIfAborted()
-    ready = JSON.parse(outcome.line) as Partial<ProxyReadySignal>
-    if (ready.type !== 'ready' || !ready.port || !childPid) {
+    const parsed = JSON.parse(outcome.line) as Partial<ProxyReadySignal>
+    if (parsed.type !== 'ready' || !parsed.port || !childPid) {
       throw new Error(`Unexpected proxy output: ${outcome.line}`)
     }
+    ready = { type: 'ready', port: parsed.port, models: parsed.models ?? [] }
     stderrCapture.finishStartup()
   } catch (error) {
     // Single failure funnel: startup timeout, pre-ready exit, pre-ready
@@ -1035,7 +1036,7 @@ async function spawnProxy(
   // Don't let the child keep the parent alive
   child.unref()
 
-  return { port: ready.port, pid: childPid, generation, models: ready.models ?? [] }
+  return { port: ready.port, pid: childPid, generation, models: ready.models }
 }
 
 function startHeartbeat(

--- a/packages/pi-cursor/src/proxy-lifecycle.ts
+++ b/packages/pi-cursor/src/proxy-lifecycle.ts
@@ -28,6 +28,7 @@ import {
 } from './proxy-timeouts.ts'
 import { isDebugLoggingEnabled, logProxyStderr } from './proxy/debug-logger.ts'
 import type { CursorModel } from './proxy/models.ts'
+import type { ProxyReadySignal } from './proxy/proxy-ready.ts'
 import { withSharedLock } from './shared-lock.ts'
 
 const PORT_FILE = join(homedir(), '.pi', 'agent', 'cursor-proxy.json')
@@ -908,7 +909,7 @@ async function spawnProxy(
     }
   }
 
-  let ready: { type: string; port: number; models?: CursorModel[] }
+  let ready: Partial<ProxyReadySignal>
   try {
     const outcome = await new Promise<StartupOutcome>((resolve) => {
       // Startup terminal state. The first of ready line, startup timeout,
@@ -996,7 +997,7 @@ async function spawnProxy(
       throw new Error(outcome.message, { cause: outcome.cause })
     }
     options.signal?.throwIfAborted()
-    ready = JSON.parse(outcome.line) as { type: string; port: number; models?: CursorModel[] }
+    ready = JSON.parse(outcome.line) as Partial<ProxyReadySignal>
     if (ready.type !== 'ready' || !ready.port || !childPid) {
       throw new Error(`Unexpected proxy output: ${outcome.line}`)
     }

--- a/packages/pi-cursor/src/proxy/main.ts
+++ b/packages/pi-cursor/src/proxy/main.ts
@@ -28,6 +28,7 @@ import {
 } from './internal-api.ts'
 import { processModels, type NormalizedModelSet } from './model-normalization.ts'
 import { discoverCursorModels, type CursorModel } from './models.ts'
+import { buildProxyReadySignal } from './proxy-ready.ts'
 import { handleChatCompletion, type ProxyContext } from './request-lifecycle.ts'
 import { closeAll, evict, type ConversationConfig } from './session-state.ts'
 import { createShutdownController } from './shutdown.ts'
@@ -208,18 +209,7 @@ async function main(): Promise<void> {
     listeningPort = port
 
     // 7. Write ready signal to stdout (extension reads this)
-    const readySignal = JSON.stringify({
-      type: 'ready',
-      port,
-      models: models.map((m) => ({
-        id: m.id,
-        name: m.name,
-        reasoning: m.reasoning,
-        contextWindow: m.contextWindow,
-        maxTokens: m.maxTokens,
-        supportsImages: m.supportsImages,
-      })),
-    })
+    const readySignal = JSON.stringify(buildProxyReadySignal(port, models))
     console.log(readySignal)
 
     // 8. Start heartbeat monitor

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -404,6 +404,37 @@ describe('resolveModelId', () => {
     expect(resolveModelId('claude-opus-4-6', 'xhigh', false, true, modelSet)).toBe('claude-4.6-opus-max-thinking')
   })
 
+  it('ignores effort when a model only has default thinking variants', () => {
+    const modelSet = processModels([
+      makeModel('claude-haiku-4-5', {
+        legacySlugs: ['claude-4.5-haiku', 'claude-4.5-haiku-thinking'],
+      }),
+    ])
+
+    expect(resolveModelId('claude-haiku-4-5', 'low', false, true, modelSet)).toBe('claude-4.5-haiku-thinking')
+    expect(resolveModelId('claude-haiku-4-5', 'low', false, false, modelSet)).toBe('claude-4.5-haiku')
+  })
+
+  it('preserves thinking by falling back to its default effort', () => {
+    const modelSet = processModels([
+      makeModel('claude-example', {
+        legacySlugs: ['claude-example-low', 'claude-example-thinking'],
+      }),
+    ])
+
+    expect(resolveModelId('claude-example', 'low', false, true, modelSet)).toBe('claude-example-thinking')
+  })
+
+  it('drops fast before thinking when their combination is unavailable', () => {
+    const modelSet = processModels([
+      makeModel('claude-example', {
+        legacySlugs: ['claude-example-low-fast', 'claude-example-high', 'claude-example-high-thinking'],
+      }),
+    ])
+
+    expect(resolveModelId('claude-example', 'high', true, true, modelSet)).toBe('claude-example-high-thinking')
+  })
+
   it('resolves unknown model ID → returns as-is', () => {
     const modelSet = buildGptModelSet()
     expect(resolveModelId('unknown-model', 'high', true, false, modelSet)).toBe('unknown-model')

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -95,6 +95,33 @@ describe('parseSlug', () => {
     })
   })
 
+  it('parses thinking before effort', () => {
+    expect(parseSlug('claude-opus-4-7-thinking-medium')).toEqual({
+      base: 'claude-opus-4-7',
+      effort: 'medium',
+      thinking: true,
+      fast: false,
+    })
+  })
+
+  it('parses fast before effort', () => {
+    expect(parseSlug('grok-4.5-fast-medium')).toEqual({
+      base: 'grok-4.5',
+      effort: 'medium',
+      thinking: false,
+      fast: true,
+    })
+  })
+
+  it('parses thinking and fast before effort', () => {
+    expect(parseSlug('claude-opus-4-7-thinking-low-fast')).toEqual({
+      base: 'claude-opus-4-7',
+      effort: 'low',
+      thinking: true,
+      fast: true,
+    })
+  })
+
   it('parses -none effort', () => {
     expect(parseSlug('gpt-5.4-none')).toEqual({
       base: 'gpt-5.4',

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -445,6 +445,36 @@ describe('resolveModelId', () => {
     expect(resolveModelId('claude-example', 'low', false, true, modelSet)).toBe('claude-example-thinking')
   })
 
+  it('keeps requested effort instead of remapping inside a sparse thinking variant', () => {
+    const modelSet = processModels([
+      makeModel('claude-opus-5', {
+        legacySlugs: [
+          'claude-opus-5-low',
+          'claude-opus-5-medium',
+          'claude-opus-5-high',
+          'claude-opus-5-thinking-high',
+          'claude-opus-5-thinking-xhigh',
+          'claude-opus-5-thinking-max',
+        ],
+      }),
+    ])
+
+    expect(resolveModelId('claude-opus-5', 'low', false, true, modelSet)).toBe('claude-opus-5-low')
+    expect(resolveModelId('claude-opus-5', 'medium', false, true, modelSet)).toBe('claude-opus-5-medium')
+    expect(resolveModelId('claude-opus-5', 'high', false, true, modelSet)).toBe('claude-opus-5-thinking-high')
+  })
+
+  it('keeps family xhigh on the selector map without changing exact wire resolution', () => {
+    const modelSet = processModels([
+      makeModel('grok-4.6', {
+        legacySlugs: ['cursor-grok-4.6-xhigh', 'cursor-grok-4.6-xhigh-fast', 'grok-4.6-xhigh', 'grok-4.6-xhigh-fast'],
+      }),
+    ])
+
+    expect(modelSet.effortMaps.get('grok-4.6')?.xhigh).toBe('xhigh')
+    expect(resolveModelId('grok-4.6', 'xhigh', true, false, modelSet)).toBe('cursor-grok-4.6-xhigh-fast')
+  })
+
   it('drops fast before thinking when their combination is unavailable', () => {
     const modelSet = processModels([
       makeModel('claude-example', {
@@ -549,6 +579,38 @@ describe('current Cursor legacy slug regressions', () => {
       fast: false,
       thinking: false,
       expected: 'claude-opus-5-high',
+    },
+    {
+      name: 'Claude Opus 5 low thinking keeps non-thinking low',
+      id: 'claude-opus-5',
+      legacySlugs: [
+        'claude-opus-5-low',
+        'claude-opus-5-medium',
+        'claude-opus-5-high',
+        'claude-opus-5-thinking-high',
+        'claude-opus-5-thinking-xhigh',
+        'claude-opus-5-thinking-max',
+      ],
+      effort: 'low',
+      fast: false,
+      thinking: true,
+      expected: 'claude-opus-5-low',
+    },
+    {
+      name: 'Claude Opus 5 medium thinking keeps non-thinking medium',
+      id: 'claude-opus-5',
+      legacySlugs: [
+        'claude-opus-5-low',
+        'claude-opus-5-medium',
+        'claude-opus-5-high',
+        'claude-opus-5-thinking-high',
+        'claude-opus-5-thinking-xhigh',
+        'claude-opus-5-thinking-max',
+      ],
+      effort: 'medium',
+      fast: false,
+      thinking: true,
+      expected: 'claude-opus-5-medium',
     },
     {
       name: 'Claude Sonnet 5 reordered thinking suffix',

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -369,6 +369,16 @@ describe('resolveModelId', () => {
     expect(resolveModelId('gpt-5.4', 'xhigh', false, false, modelSet)).toBe('gpt-5.4-xhigh')
   })
 
+  it('accepts an already-mapped Cursor effort', () => {
+    const modelSet = processModels([
+      makeModel('gpt-5.5', {
+        legacySlugs: ['gpt-5.5-high-fast', 'gpt-5.5-extra-high-fast'],
+      }),
+    ])
+
+    expect(resolveModelId('gpt-5.5', 'extra-high', true, false, modelSet)).toBe('gpt-5.5-extra-high-fast')
+  })
+
   it('resolves GPT with no effort → returns model ID as-is', () => {
     const modelSet = buildGptModelSet()
     expect(resolveModelId('gpt-5.4', null, false, false, modelSet)).toBe('gpt-5.4')
@@ -413,6 +423,16 @@ describe('resolveModelId', () => {
 
     expect(resolveModelId('claude-haiku-4-5', 'low', false, true, modelSet)).toBe('claude-4.5-haiku-thinking')
     expect(resolveModelId('claude-haiku-4-5', 'low', false, false, modelSet)).toBe('claude-4.5-haiku')
+  })
+
+  it('maps an unavailable Cursor max effort within the selected variant', () => {
+    const modelSet = processModels([
+      makeModel('claude-opus-5', {
+        legacySlugs: ['claude-opus-5-low', 'claude-opus-5-medium', 'claude-opus-5-high', 'claude-opus-5-thinking-max'],
+      }),
+    ])
+
+    expect(resolveModelId('claude-opus-5', 'max', false, false, modelSet)).toBe('claude-opus-5-high')
   })
 
   it('preserves thinking by falling back to its default effort', () => {

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -440,3 +440,146 @@ describe('resolveModelId', () => {
     expect(resolveModelId('unknown-model', 'high', true, false, modelSet)).toBe('unknown-model')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Current Cursor legacy slug regressions
+// ---------------------------------------------------------------------------
+
+describe('current Cursor legacy slug regressions', () => {
+  const cases: {
+    name: string
+    id: string
+    legacySlugs: string[]
+    effort: string
+    fast: boolean
+    thinking: boolean
+    expected: string
+  }[] = [
+    {
+      name: 'Claude Haiku 4.5 default thinking variant',
+      id: 'claude-haiku-4-5',
+      legacySlugs: ['claude-4.5-haiku', 'claude-4.5-haiku-thinking'],
+      effort: 'low',
+      fast: false,
+      thinking: true,
+      expected: 'claude-4.5-haiku-thinking',
+    },
+    {
+      name: 'Claude Sonnet 4 default thinking variant',
+      id: 'claude-sonnet-4',
+      legacySlugs: ['claude-4-sonnet', 'claude-4-sonnet-thinking'],
+      effort: 'high',
+      fast: false,
+      thinking: true,
+      expected: 'claude-4-sonnet-thinking',
+    },
+    {
+      name: 'Claude Sonnet 4.5 default thinking variant',
+      id: 'claude-sonnet-4-5',
+      legacySlugs: ['claude-4.5-sonnet', 'claude-4.5-sonnet-thinking'],
+      effort: 'xhigh',
+      fast: false,
+      thinking: true,
+      expected: 'claude-4.5-sonnet-thinking',
+    },
+    {
+      name: 'Claude Fable 5 reordered thinking suffix',
+      id: 'claude-fable-5',
+      legacySlugs: ['claude-fable-5-medium', 'claude-fable-5-thinking-medium'],
+      effort: 'medium',
+      fast: false,
+      thinking: true,
+      expected: 'claude-fable-5-thinking-medium',
+    },
+    {
+      name: 'Claude Opus 4.7 reordered thinking and fast suffixes',
+      id: 'claude-opus-4-7',
+      legacySlugs: [
+        'claude-opus-4-7-high',
+        'claude-opus-4-7-high-fast',
+        'claude-opus-4-7-thinking-high',
+        'claude-opus-4-7-thinking-high-fast',
+      ],
+      effort: 'high',
+      fast: true,
+      thinking: true,
+      expected: 'claude-opus-4-7-thinking-high-fast',
+    },
+    {
+      name: 'Claude Opus 4.8 reordered thinking suffix',
+      id: 'claude-opus-4-8',
+      legacySlugs: ['claude-opus-4-8-medium', 'claude-opus-4-8-thinking-medium'],
+      effort: 'medium',
+      fast: false,
+      thinking: true,
+      expected: 'claude-opus-4-8-thinking-medium',
+    },
+    {
+      name: 'Claude Opus 5 sparse non-thinking efforts',
+      id: 'claude-opus-5',
+      legacySlugs: [
+        'claude-opus-5-low',
+        'claude-opus-5-medium',
+        'claude-opus-5-high',
+        'claude-opus-5-thinking-high',
+        'claude-opus-5-thinking-xhigh',
+        'claude-opus-5-thinking-max',
+      ],
+      effort: 'xhigh',
+      fast: false,
+      thinking: false,
+      expected: 'claude-opus-5-high',
+    },
+    {
+      name: 'Claude Sonnet 5 reordered thinking suffix',
+      id: 'claude-sonnet-5',
+      legacySlugs: [
+        'claude-sonnet-5-high',
+        'claude-sonnet-5-max',
+        'claude-sonnet-5-thinking-high',
+        'claude-sonnet-5-thinking-max',
+      ],
+      effort: 'xhigh',
+      fast: false,
+      thinking: true,
+      expected: 'claude-sonnet-5-thinking-max',
+    },
+    {
+      name: 'Gemini 3.6 Flash minimal effort',
+      id: 'gemini-3.6-flash',
+      legacySlugs: [
+        'gemini-3.6-flash-minimal',
+        'gemini-3.6-flash-low',
+        'gemini-3.6-flash-medium',
+        'gemini-3.6-flash-high',
+      ],
+      effort: 'minimal',
+      fast: false,
+      thinking: false,
+      expected: 'gemini-3.6-flash-minimal',
+    },
+    {
+      name: 'GPT-5.5 extra-high fast effort',
+      id: 'gpt-5.5',
+      legacySlugs: ['gpt-5.5-high', 'gpt-5.5-high-fast', 'gpt-5.5-extra-high', 'gpt-5.5-extra-high-fast'],
+      effort: 'xhigh',
+      fast: true,
+      thinking: false,
+      expected: 'gpt-5.5-extra-high-fast',
+    },
+    {
+      name: 'Grok 4.5 canonical non-fast alias',
+      id: 'grok-4.5',
+      legacySlugs: ['cursor-grok-4.5-medium', 'cursor-grok-4.5-medium-fast', 'grok-4.5-medium', 'grok-4.5-fast-medium'],
+      effort: 'medium',
+      fast: false,
+      thinking: false,
+      expected: 'cursor-grok-4.5-medium',
+    },
+  ]
+
+  it.each(cases)('$name', ({ id, legacySlugs, effort, fast, thinking, expected }) => {
+    const modelSet = processModels([makeModel(id, { legacySlugs })])
+    expect(resolveModelId(id, effort, fast, thinking, modelSet)).toBe(expected)
+  })
+})

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -122,6 +122,24 @@ describe('parseSlug', () => {
     })
   })
 
+  it('parses -minimal effort', () => {
+    expect(parseSlug('gemini-3.6-flash-minimal')).toEqual({
+      base: 'gemini-3.6-flash',
+      effort: 'minimal',
+      thinking: false,
+      fast: false,
+    })
+  })
+
+  it('parses -extra-high effort', () => {
+    expect(parseSlug('gpt-5.5-extra-high-fast')).toEqual({
+      base: 'gpt-5.5',
+      effort: 'extra-high',
+      thinking: false,
+      fast: true,
+    })
+  })
+
   it('parses -none effort', () => {
     expect(parseSlug('gpt-5.4-none')).toEqual({
       base: 'gpt-5.4',
@@ -177,10 +195,18 @@ describe('buildEffortMap', () => {
     expect(map.xhigh).toBe('xhigh')
   })
 
-  it('maps xhigh to high when neither max nor xhigh available', () => {
+  it('maps xhigh to high when no elevated effort is available', () => {
     const efforts = new Set<CursorEffort | 'default'>(['low', 'medium', 'high'])
     const map = buildEffortMap(efforts)
     expect(map.xhigh).toBe('high')
+  })
+
+  it('maps Cursor minimal and extra-high efforts', () => {
+    const efforts = new Set<CursorEffort | 'default'>(['minimal', 'low', 'medium', 'high', 'extra-high'])
+    const map = buildEffortMap(efforts)
+    expect(map.minimal).toBe('minimal')
+    expect(map.low).toBe('low')
+    expect(map.xhigh).toBe('extra-high')
   })
 
   it('maps medium to empty string for default-only', () => {

--- a/packages/pi-cursor/src/proxy/model-normalization.test.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.test.ts
@@ -296,6 +296,17 @@ describe('processModels', () => {
     expect(result.slugLookup.get('gpt-5.4|high|false|false')).toBe('gpt-5.4-high')
     expect(result.slugLookup.get('gpt-5.4|high|true|false')).toBe('gpt-5.4-high-fast')
   })
+
+  it('keeps the first slug when compatibility aliases collide', () => {
+    const models = [
+      makeModel('grok-4.5', {
+        legacySlugs: ['cursor-grok-4.5-medium', 'grok-4.5-medium'],
+      }),
+    ]
+    const result = processModels(models)
+
+    expect(result.slugLookup.get('grok-4.5|medium|false|false')).toBe('cursor-grok-4.5-medium')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -61,6 +61,15 @@ const EFFORT_SUFFIXES: ReadonlySet<string> = new Set([
   'max',
 ])
 
+/** Pi reasoning levels to the Cursor suffixes `buildEffortMap` will prefer. */
+const PI_EFFORT_PREFERENCES: Record<string, readonly (CursorEffort | 'default')[]> = {
+  minimal: ['minimal', 'none', 'low'],
+  low: ['low', 'none', 'minimal'],
+  medium: ['medium', 'default'],
+  high: ['high'],
+  xhigh: ['max', 'xhigh', 'extra-high', 'high'],
+}
+
 // ---------------------------------------------------------------------------
 // parseSlug
 // ---------------------------------------------------------------------------
@@ -151,12 +160,26 @@ export function buildEffortMap(availableEfforts: Set<CursorEffort | 'default'>):
   }
 
   return {
-    minimal: pick(['minimal', 'none', 'low'], lowest),
-    low: pick(['low', 'none', 'minimal'], lowest),
-    medium: pick(['medium', 'default'], lowest),
-    high: pick(['high'], highFallback),
-    xhigh: pick(['max', 'xhigh', 'extra-high', 'high'], highest),
+    minimal: pick([...PI_EFFORT_PREFERENCES.minimal], lowest),
+    low: pick([...PI_EFFORT_PREFERENCES.low], lowest),
+    medium: pick([...PI_EFFORT_PREFERENCES.medium], lowest),
+    high: pick([...PI_EFFORT_PREFERENCES.high], highFallback),
+    xhigh: pick([...PI_EFFORT_PREFERENCES.xhigh], highest),
   }
+}
+
+/** True when this variant would change a named Pi effort to a different named Cursor suffix. */
+function isNamedEffortRemap(
+  effort: string,
+  availableEfforts: Set<CursorEffort | 'default'>,
+  resolvedEffort: string,
+): boolean {
+  const preferred = Object.hasOwn(PI_EFFORT_PREFERENCES, effort) ? PI_EFFORT_PREFERENCES[effort] : undefined
+  if (!preferred) {
+    return false
+  }
+  const hasPreferred = preferred.some((candidate) => availableEfforts.has(candidate))
+  return !hasPreferred && resolvedEffort !== 'default'
 }
 
 function effortToSuffix(effort: CursorEffort | 'default'): string {
@@ -201,7 +224,8 @@ export function processModels(rawModels: CursorModel[]): NormalizedModelSet {
           meta.supportsThinking = true
         }
 
-        // Cursor lists preferred slugs before compatibility aliases.
+        // Cursor lists preferred slugs first; first-wins keeps that order.
+        // If the API ever lists preferred last, prefer cursor-* on collision.
         const effort = parsed.effort ?? 'default'
         const variantKey = `${model.id}|${String(parsed.fast)}|${String(parsed.thinking)}`
         const availableEfforts = variantEfforts.get(variantKey) ?? new Set<CursorEffort | 'default'>()
@@ -292,6 +316,11 @@ export function resolveModelId(
           const suffix = effortMap[piEffort]
           resolvedEffort = suffix || 'default'
         }
+      }
+
+      // Keep haiku's low → default on thinking; skip opus-style low → thinking-high.
+      if (isNamedEffortRemap(effort, availableEfforts, resolvedEffort)) {
+        continue
       }
     }
 

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -50,7 +50,16 @@ export interface NormalizedModelSet {
 // Constants
 // ---------------------------------------------------------------------------
 
-const EFFORT_SUFFIXES: ReadonlySet<string> = new Set(['minimal', 'none', 'low', 'medium', 'high', 'xhigh', 'max'])
+const EFFORT_SUFFIXES: ReadonlySet<string> = new Set([
+  'minimal',
+  'none',
+  'low',
+  'medium',
+  'high',
+  'extra-high',
+  'xhigh',
+  'max',
+])
 
 // ---------------------------------------------------------------------------
 // parseSlug
@@ -270,8 +279,19 @@ export function resolveModelId(
       if (Object.hasOwn(effortMap, effort)) {
         const suffix = effortMap[effort]
         resolvedEffort = suffix || 'default'
-      } else if (EFFORT_SUFFIXES.has(effort)) {
+      } else if (EFFORT_SUFFIXES.has(effort) && availableEfforts.has(effort as CursorEffort)) {
         resolvedEffort = effort
+      } else {
+        let piEffort: 'minimal' | 'xhigh' | null = null
+        if (effort === 'none') {
+          piEffort = 'minimal'
+        } else if (effort === 'extra-high' || effort === 'max') {
+          piEffort = 'xhigh'
+        }
+        if (piEffort) {
+          const suffix = effortMap[piEffort]
+          resolvedEffort = suffix || 'default'
+        }
       }
     }
 

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -54,43 +54,34 @@ const EFFORT_SUFFIXES: ReadonlySet<string> = new Set(['none', 'low', 'medium', '
 // parseSlug
 // ---------------------------------------------------------------------------
 
-/**
- * Parse a legacy slug by stripping suffixes in order:
- * 1. Strip `-fast` → speed variant
- * 2. Strip `-thinking` → thinking variant
- * 3. Parse effort from last remaining segment
- * 4. Remaining segments → base name
- */
+/** Parse a legacy slug whose effort, thinking, and fast suffixes can appear in any order. */
 export function parseSlug(slug: string): ParsedSlug {
-  let remaining = slug
-
-  // 1. Strip -fast
-  let fast = false
-  if (remaining.endsWith('-fast')) {
-    fast = true
-    remaining = remaining.slice(0, -5)
-  }
-
-  // 2. Strip -thinking
-  let thinking = false
-  if (remaining.endsWith('-thinking')) {
-    thinking = true
-    remaining = remaining.slice(0, -9)
-  }
-
-  // 3. Parse effort from last segment
+  const segments = slug.split('-')
   let effort: CursorEffort | null = null
-  const segments = remaining.split('-')
-  if (segments.length > 1) {
+  let thinking = false
+  let fast = false
+
+  while (segments.length > 1) {
     const lastSegment = segments.at(-1) ?? ''
-    if (EFFORT_SUFFIXES.has(lastSegment)) {
+    if (lastSegment === 'fast') {
+      fast = true
+      segments.pop()
+      continue
+    }
+    if (lastSegment === 'thinking') {
+      thinking = true
+      segments.pop()
+      continue
+    }
+    if (effort === null && EFFORT_SUFFIXES.has(lastSegment)) {
       effort = lastSegment as CursorEffort
       segments.pop()
-      remaining = segments.join('-')
+      continue
     }
+    break
   }
 
-  return { base: remaining, effort, thinking, fast }
+  return { base: segments.join('-'), effort, thinking, fast }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -37,6 +37,8 @@ export interface NormalizedModelSet {
   modelMeta: Map<string, ModelMeta>
   /** Effort maps keyed by model ID */
   effortMaps: Map<string, Record<string, string>>
+  /** Available efforts keyed by "(modelId)|(fast)|(thinking)" */
+  variantEfforts: Map<string, Set<CursorEffort | 'default'>>
   /**
    * Slug resolution table: maps "(modelId)|(effort)|(fast)|(thinking)" to the
    * legacy slug that Cursor's server accepts.
@@ -166,6 +168,7 @@ function effortToSuffix(effort: CursorEffort | 'default'): string {
 export function processModels(rawModels: CursorModel[]): NormalizedModelSet {
   const modelMeta = new Map<string, ModelMeta>()
   const effortMaps = new Map<string, Record<string, string>>()
+  const variantEfforts = new Map<string, Set<CursorEffort | 'default'>>()
   const slugLookup = new Map<string, string>()
 
   for (const model of rawModels) {
@@ -191,6 +194,11 @@ export function processModels(rawModels: CursorModel[]): NormalizedModelSet {
 
         // Cursor lists preferred slugs before compatibility aliases.
         const effort = parsed.effort ?? 'default'
+        const variantKey = `${model.id}|${String(parsed.fast)}|${String(parsed.thinking)}`
+        const availableEfforts = variantEfforts.get(variantKey) ?? new Set<CursorEffort | 'default'>()
+        availableEfforts.add(effort)
+        variantEfforts.set(variantKey, availableEfforts)
+
         const key = `${model.id}|${effort}|${String(parsed.fast)}|${String(parsed.thinking)}`
         if (!slugLookup.has(key)) {
           slugLookup.set(key, slug)
@@ -207,7 +215,7 @@ export function processModels(rawModels: CursorModel[]): NormalizedModelSet {
     }
   }
 
-  return { models: rawModels, modelMeta, effortMaps, slugLookup }
+  return { models: rawModels, modelMeta, effortMaps, variantEfforts, slugLookup }
 }
 
 // ---------------------------------------------------------------------------
@@ -233,18 +241,6 @@ export function resolveModelId(
     return modelId
   }
 
-  // Resolve effort suffix from effort map
-  let resolvedEffort = 'default'
-  if (effort) {
-    const effortMap = modelSet.effortMaps.get(modelId)
-    if (effortMap && Object.hasOwn(effortMap, effort)) {
-      const suffix = effortMap[effort]
-      resolvedEffort = suffix || 'default'
-    } else if (effortMap && EFFORT_SUFFIXES.has(effort)) {
-      resolvedEffort = effort
-    }
-  }
-
   // Silently ignore flags the model doesn't support.
   const effectiveFast = fast && meta.supportsFast
   const effectiveThinking = thinking && meta.supportsThinking
@@ -261,14 +257,28 @@ export function resolveModelId(
     flagCandidates.push([false, false])
   }
 
-  const effortCandidates = resolvedEffort === 'default' ? ['default'] : [resolvedEffort, 'default']
   for (const [candidateFast, candidateThinking] of flagCandidates) {
-    for (const candidateEffort of effortCandidates) {
-      const key = `${modelId}|${candidateEffort}|${String(candidateFast)}|${String(candidateThinking)}`
-      const slug = modelSet.slugLookup.get(key)
-      if (slug) {
-        return slug
+    const variantKey = `${modelId}|${String(candidateFast)}|${String(candidateThinking)}`
+    const availableEfforts = modelSet.variantEfforts.get(variantKey)
+    if (!availableEfforts) {
+      continue
+    }
+
+    let resolvedEffort = 'default'
+    if (effort) {
+      const effortMap = buildEffortMap(availableEfforts)
+      if (Object.hasOwn(effortMap, effort)) {
+        const suffix = effortMap[effort]
+        resolvedEffort = suffix || 'default'
+      } else if (EFFORT_SUFFIXES.has(effort)) {
+        resolvedEffort = effort
       }
+    }
+
+    const key = `${modelId}|${resolvedEffort}|${String(candidateFast)}|${String(candidateThinking)}`
+    const slug = modelSet.slugLookup.get(key)
+    if (slug) {
+      return slug
     }
   }
 

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -189,10 +189,12 @@ export function processModels(rawModels: CursorModel[]): NormalizedModelSet {
           meta.supportsThinking = true
         }
 
-        // Build slug lookup key: "modelId|effort|fast|thinking"
+        // Cursor lists preferred slugs before compatibility aliases.
         const effort = parsed.effort ?? 'default'
         const key = `${model.id}|${effort}|${String(parsed.fast)}|${String(parsed.thinking)}`
-        slugLookup.set(key, slug)
+        if (!slugLookup.has(key)) {
+          slugLookup.set(key, slug)
+        }
       }
     }
 

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -240,49 +240,38 @@ export function resolveModelId(
     if (effortMap && Object.hasOwn(effortMap, effort)) {
       const suffix = effortMap[effort]
       resolvedEffort = suffix || 'default'
-    } else if (EFFORT_SUFFIXES.has(effort)) {
+    } else if (effortMap && EFFORT_SUFFIXES.has(effort)) {
       resolvedEffort = effort
     }
   }
 
-  // Silently ignore flags the model doesn't support
+  // Silently ignore flags the model doesn't support.
   const effectiveFast = fast && meta.supportsFast
   const effectiveThinking = thinking && meta.supportsThinking
+  const flagCandidates: [fast: boolean, thinking: boolean][] = [[effectiveFast, effectiveThinking]]
 
-  // Look up the legacy slug
-  const key = `${modelId}|${resolvedEffort}|${String(effectiveFast)}|${String(effectiveThinking)}`
-  const slug = modelSet.slugLookup.get(key)
-  if (slug) {
-    return slug
-  }
-
-  // Fallback: try without thinking
-  if (effectiveThinking) {
-    const keyNoThinking = `${modelId}|${resolvedEffort}|${String(effectiveFast)}|false`
-    const slugNoThinking = modelSet.slugLookup.get(keyNoThinking)
-    if (slugNoThinking) {
-      return slugNoThinking
-    }
-  }
-
-  // Fallback: try without fast
+  // Preserve thinking when the exact fast variant is unavailable.
   if (effectiveFast) {
-    const keyNoFast = `${modelId}|${resolvedEffort}|false|${String(effectiveThinking)}`
-    const slugNoFast = modelSet.slugLookup.get(keyNoFast)
-    if (slugNoFast) {
-      return slugNoFast
+    flagCandidates.push([false, effectiveThinking])
+  }
+  if (effectiveThinking) {
+    flagCandidates.push([effectiveFast, false])
+  }
+  if (effectiveFast && effectiveThinking) {
+    flagCandidates.push([false, false])
+  }
+
+  const effortCandidates = resolvedEffort === 'default' ? ['default'] : [resolvedEffort, 'default']
+  for (const [candidateFast, candidateThinking] of flagCandidates) {
+    for (const candidateEffort of effortCandidates) {
+      const key = `${modelId}|${candidateEffort}|${String(candidateFast)}|${String(candidateThinking)}`
+      const slug = modelSet.slugLookup.get(key)
+      if (slug) {
+        return slug
+      }
     }
   }
 
-  // Fallback: try bare effort only
-  if (resolvedEffort !== 'default') {
-    const keyBare = `${modelId}|${resolvedEffort}|false|false`
-    const slugBare = modelSet.slugLookup.get(keyBare)
-    if (slugBare) {
-      return slugBare
-    }
-  }
-
-  // No slug found — return model ID as-is (e.g. gemini models with no legacy slugs)
+  // The normalized model ID represents the default non-fast, non-thinking variant.
   return modelId
 }

--- a/packages/pi-cursor/src/proxy/model-normalization.ts
+++ b/packages/pi-cursor/src/proxy/model-normalization.ts
@@ -5,7 +5,7 @@ import type { CursorModel } from './models.ts'
 // ---------------------------------------------------------------------------
 
 /** Effort suffixes found in Cursor legacy slug model IDs */
-export type CursorEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type CursorEffort = 'minimal' | 'none' | 'low' | 'medium' | 'high' | 'extra-high' | 'xhigh' | 'max'
 
 /** Result of parsing a legacy slug into its components */
 export interface ParsedSlug {
@@ -48,7 +48,7 @@ export interface NormalizedModelSet {
 // Constants
 // ---------------------------------------------------------------------------
 
-const EFFORT_SUFFIXES: ReadonlySet<string> = new Set(['none', 'low', 'medium', 'high', 'xhigh', 'max'])
+const EFFORT_SUFFIXES: ReadonlySet<string> = new Set(['minimal', 'none', 'low', 'medium', 'high', 'xhigh', 'max'])
 
 // ---------------------------------------------------------------------------
 // parseSlug
@@ -73,6 +73,11 @@ export function parseSlug(slug: string): ParsedSlug {
       segments.pop()
       continue
     }
+    if (effort === null && lastSegment === 'high' && segments.at(-2) === 'extra') {
+      effort = 'extra-high'
+      segments.splice(-2)
+      continue
+    }
     if (effort === null && EFFORT_SUFFIXES.has(lastSegment)) {
       effort = lastSegment as CursorEffort
       segments.pop()
@@ -91,14 +96,24 @@ export function parseSlug(slug: string): ParsedSlug {
 /**
  * Map Pi's effort levels to the best available Cursor effort suffix.
  *
- * - minimal → none if available, else low, else lowest available
- * - low → low if available, else none, else lowest available
+ * - minimal → minimal if available, then none, then low
+ * - low → low if available, then none, then minimal
  * - medium → medium if available, else 'default' (no suffix)
- * - high → high if available, else highest below xhigh
- * - xhigh → max if available, else xhigh, else high
+ * - high → high if available, else highest lower effort
+ * - xhigh → max if available, then xhigh, then extra-high, then high
  */
 export function buildEffortMap(availableEfforts: Set<CursorEffort | 'default'>): Record<string, string> {
-  const orderedEfforts: (CursorEffort | 'default')[] = ['none', 'low', 'default', 'medium', 'high', 'xhigh', 'max']
+  const orderedEfforts: (CursorEffort | 'default')[] = [
+    'minimal',
+    'none',
+    'low',
+    'default',
+    'medium',
+    'high',
+    'extra-high',
+    'xhigh',
+    'max',
+  ]
   const available = orderedEfforts.filter((e) => availableEfforts.has(e))
 
   if (available.length === 0) {
@@ -117,14 +132,19 @@ export function buildEffortMap(availableEfforts: Set<CursorEffort | 'default'>):
     return effortToSuffix(fallback)
   }
 
-  const highFallback: CursorEffort | 'default' = highest === 'max' || highest === 'xhigh' ? 'high' : highest
+  let highFallback = highest
+  for (const candidate of available) {
+    if (candidate !== 'extra-high' && candidate !== 'xhigh' && candidate !== 'max') {
+      highFallback = candidate
+    }
+  }
 
   return {
-    minimal: pick(['none', 'low'], lowest),
-    low: pick(['low', 'none'], lowest),
+    minimal: pick(['minimal', 'none', 'low'], lowest),
+    low: pick(['low', 'none', 'minimal'], lowest),
     medium: pick(['medium', 'default'], lowest),
     high: pick(['high'], highFallback),
-    xhigh: pick(['max', 'xhigh', 'high'], highest),
+    xhigh: pick(['max', 'xhigh', 'extra-high', 'high'], highest),
   }
 }
 

--- a/packages/pi-cursor/src/proxy/proxy-ready.test.ts
+++ b/packages/pi-cursor/src/proxy/proxy-ready.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CursorModel } from './models.ts'
+import { buildProxyReadySignal } from './proxy-ready.ts'
+
+describe('buildProxyReadySignal', () => {
+  it('preserves model metadata needed by the extension', () => {
+    const models: CursorModel[] = [
+      {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        reasoning: true,
+        contextWindow: 200_000,
+        contextWindowMaxMode: 1_000_000,
+        maxTokens: 64_000,
+        supportsImages: true,
+        supportsMaxMode: true,
+        legacySlugs: ['gpt-5.5-high', 'gpt-5.5-extra-high'],
+      },
+    ]
+
+    const signal = buildProxyReadySignal(4321, models)
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- Verify JSON process-boundary serialization.
+    const roundTripped = JSON.parse(JSON.stringify(signal)) as typeof signal
+
+    expect(roundTripped).toEqual({ type: 'ready', port: 4321, models })
+    expect(roundTripped.models[0]?.legacySlugs).toEqual(['gpt-5.5-high', 'gpt-5.5-extra-high'])
+    expect(roundTripped.models[0]?.contextWindowMaxMode).toBe(1_000_000)
+    expect(roundTripped.models[0]?.supportsMaxMode).toBeTruthy()
+  })
+})

--- a/packages/pi-cursor/src/proxy/proxy-ready.ts
+++ b/packages/pi-cursor/src/proxy/proxy-ready.ts
@@ -1,0 +1,12 @@
+import type { CursorModel } from './models.ts'
+
+/** Startup payload sent from the proxy process to the extension process. */
+export interface ProxyReadySignal {
+  type: 'ready'
+  port: number
+  models: CursorModel[]
+}
+
+export function buildProxyReadySignal(port: number, models: CursorModel[]): ProxyReadySignal {
+  return { type: 'ready', port, models }
+}


### PR DESCRIPTION
Cursor model routing now parses Fast, thinking, and effort suffixes in any order, keeps Cursor's preferred legacy slug when aliases collide, and forwards full model metadata through the proxy ready payload so Pi can keep levels such as `xhigh` selectable.

Request-time resolve uses per-variant effort sets. If the selected thinking or Fast variant has no preferred match for a named Pi effort, it tries the next flag candidate instead of remapping that effort (for example Opus 5 `low`+thinking stays `claude-opus-5-low`, while Haiku still keeps its effort-less thinking slug). The selector map stays family-union so Pi does not clamp `xhigh`.

This continues the work in #33 and Closes #31.
