### PR TITLE
ci: restore GitHub releases with changesets/action v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test changed packages
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm --filter "...[origin/${{ github.base_ref }}]" run test
+            pnpm --filter "...{packages/**}[origin/${{ github.base_ref }}]" run test
           else
-            pnpm --filter "...[HEAD~1]" run test
+            pnpm --filter "...{packages/**}[HEAD~1]" run test
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
       - run: pnpm run test
 
       - name: Create release PR or publish
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version: pnpm run version
-          publish: pnpm run release
+          version-script: pnpm run version
+          publish-script: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/pi-cursor/src/proxy-lifecycle.test.ts
+++ b/packages/pi-cursor/src/proxy-lifecycle.test.ts
@@ -1594,6 +1594,7 @@ describe('post-ready child exit recovery', () => {
       await waitFor(() => exits.includes(first.pid))
 
       expect(getActivePort()).toBeNull()
+      await waitFor(() => existsSync(lifecycleFilePath), REAL_PENDING_DEADLINE_MS)
       const exitRecord = JSON.parse(readFileSync(lifecycleFilePath, 'utf8')) as Record<string, unknown>
       expect(exitRecord).toMatchObject({
         childPid: first.pid,


### PR DESCRIPTION
## Summary
- Bump `changesets/action` to v2.1.1 so it reads CLI v3's `CHANGESETS_OUTPUT` file instead of parsing `New tag:` from stdout. After the `@changesets/cli` 2→3 upgrade, npm published `@schultzp2020/pi-cursor@0.5.1` but the git tag and GitHub Release were skipped.
- Scope CI tests to `{packages/**}` so Version Packages merges (which change root `.changeset` files) do not also run the workspace root's recursive `pnpm -r run test` in parallel with the package suite.
- Wait for the proxy lifecycle file to exist after child exit before reading it, matching the async persist path that caused the `ENOENT` flake on `#39`.

This does not backfill the missing `@schultzp2020/pi-cursor@0.5.1` GitHub Release; that still needs a one-time tag/release for the already-published npm package.

## Test plan
- [ ] CI on this PR is green (single `pi-cursor` test run, no root recursive double-run)
- [ ] After merge, the next Version Packages publish creates both the npm version and a GitHub Release/tag
- [ ] Optionally create the missing `@schultzp2020/pi-cursor@0.5.1` GitHub Release for the package already on npm


Made with [Cursor](https://cursor.com)