### PR TITLE
ci: fix pnpm changed-package filter on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test changed packages
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm --filter "...{packages/**}[origin/${{ github.base_ref }}]" run test
+            pnpm --filter "...*[origin/${{ github.base_ref }}]" run test
           else
-            pnpm --filter "...{packages/**}[HEAD~1]" run test
+            pnpm --filter "...*[HEAD~1]" run test
           fi


### PR DESCRIPTION
## Summary
- Replace `{packages/**}[since]`, which makes pnpm throw `ERR_PNPM_FILTER_CHANGED` (empty git stderr) and failed both PR CI and the `#43` push to `main`.
- Keep the git-range filter that already worked, but require a package name (`...*[since]`) so the unnamed workspace root is not selected and Version Packages merges do not double-run tests.

## Test plan
- [ ] This PR's CI `Test changed packages` step exits 0 (workflow-only change may match no packages; it must not crash)
- [ ] After merge, a `main` push that touches `packages/pi-cursor` runs that package's tests once


Made with [Cursor](https://cursor.com)